### PR TITLE
Core Components 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,19 +538,19 @@
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.all</artifactId>
                 <type>zip</type>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
             </dependency>
             <dependency>
-           		<groupId>com.adobe.cq</groupId>
-           		<artifactId>core.wcm.components.core</artifactId>
-           		<version>2.4.0</version>
-           		<scope>provided</scope>
-        	</dependency>
+                <groupId>com.adobe.cq</groupId>
+                <artifactId>core.wcm.components.core</artifactId>
+                <version>2.5.0</version>
+                <scope>provided</scope>
+            </dependency>
             <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.examples</artifactId>
                 <type>zip</type>
-                <version>2.4.0</version>
+                <version>2.5.0</version>
             </dependency>
             <!-- Apache Sling Dependencies -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -538,19 +538,19 @@
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.all</artifactId>
                 <type>zip</type>
-                <version>2.5.0</version>
+                <version>2.6.0</version>
             </dependency>
             <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.core</artifactId>
-                <version>2.5.0</version>
+                <version>2.6.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>com.adobe.cq</groupId>
                 <artifactId>core.wcm.components.examples</artifactId>
                 <type>zip</type>
-                <version>2.5.0</version>
+                <version>2.6.0</version>
             </dependency>
             <!-- Apache Sling Dependencies -->
             <dependency>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-base/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-base/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[wknd.base]"
-    embed="[wknd.webfonts,vendor.animatecss,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,wknd.breadcrumb,wknd.site]"/>
+    embed="[wknd.webfonts,vendor.animatecss,core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,wknd.breadcrumb,wknd.site]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/accordion/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/accordion/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:isContainer="true"
+    jcr:primaryType="cq:Component"
+    jcr:title="Accordion"
+    sling:resourceSuperType="core/wcm/components/accordion/v1/accordion"
+    componentGroup="WKND.Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/accordion/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/accordion/_cq_editConfig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afterchilddelete="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_DELETE"
+        afterchildinsert="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_INSERT"
+        afterchildmove="CQ.CoreComponents.panelcontainer.v1.AFTER_CHILD_MOVE"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/accordion/_cq_template/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/accordion/_cq_template/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" jcr:primaryType="nt:unstructured">
+    <item_1 jcr:primaryType="nt:unstructured"
+            jcr:title="Item 1"
+            sling:resourceType="wcm/foundation/components/responsivegrid"/>
+    <item_2 jcr:primaryType="nt:unstructured"
+            jcr:title="Item 2"
+            sling:resourceType="wcm/foundation/components/responsivegrid"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/button/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/button/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Button"
+    sling:resourceSuperType="core/wcm/components/button/v1/button"
+    componentGroup="WKND.Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/container/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/container/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:isContainer="true"
+    jcr:primaryType="cq:Component"
+    jcr:title="Container"
+    sling:resourceSuperType="core/wcm/components/container/v1/container"
+    componentGroup="WKND.Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/download/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/download/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Download"
+    sling:resourceSuperType="core/wcm/components/download/v1/download"
+    componentGroup="WKND.Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/experiencefragment/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/experiencefragment/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="Displays an experience fragment variation"
+    jcr:primaryType="cq:Component"
+    jcr:title="Experience Fragment"
+    sling:resourceSuperType="core/wcm/components/experiencefragment/v1/experiencefragment"
+    componentGroup="WKND.Content"/>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/experiencefragment/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/experiencefragment/.content.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:description="Displays an experience fragment variation"
     jcr:primaryType="cq:Component"
     jcr:title="Experience Fragment"
     sling:resourceSuperType="core/wcm/components/experiencefragment/v1/experiencefragment"

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/experiencefragment/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/experiencefragment/_cq_editConfig.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:EditConfig"
+    cq:actions="[EDIT,DELETE,INSERT,COPYMOVE]">
+    <cq:dropTargets
+        jcr:primaryType="nt:unstructured">
+        <experiencefragment
+            jcr:primaryType="cq:DropTargetConfig"
+            accept="[text/html]"
+            propertyName="./fragmentVariationPath"
+            groups="[content]"/>
+    </cq:dropTargets>
+    <cq:listeners
+        jcr:primaryType="nt:unstructured"
+        afterinsert="REFRESH_PAGE"/>
+    <cq:actionConfigs
+        jcr:primaryType="nt:unstructured">
+        <editInNewTab
+            jcr:primaryType="nt:unstructured"
+            text="Edit"
+            handler="Granite.author.experienceFragments &amp;&amp; Granite.author.experienceFragments.actions.editInNewTab"
+            icon="edit"/>
+    </cq:actionConfigs>
+</jcr:root>


### PR DESCRIPTION
Updates the WKND guide for the recent [Core Components 2.5.0 release](https://github.com/adobe/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.5.0).

- updates core components dependencies 2.4.0 -> 2.6.0
- adds proxy components for accordion, button, container, download, experience fragment
- adds accordion clientlib embed

@godanny86 