### PR TITLE
moving site clientlibrary to be included via template

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-base/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-base/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[wknd.base]"
-    embed="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,wknd.grid,wknd.site]"/>
+    embed="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,wknd.grid]"/>

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/policies/.content.xml
@@ -916,11 +916,12 @@
                 </search>
                 <page jcr:primaryType="nt:unstructured">
                     <policy_1555624447675
-                        jcr:lastModified="{Date}2019-09-20T10:11:38.284-07:00"
+                        jcr:lastModified="{Date}2019-09-26T15:03:19.053-07:00"
                         jcr:lastModifiedBy="admin"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="WKND Landing Page"
-                        sling:resourceType="wcm/core/components/policy/policy">
+                        sling:resourceType="wcm/core/components/policy/policy"
+                        clientlibs="wknd.site">
                         <jcr:content jcr:primaryType="nt:unstructured"/>
                         <cq:styleGroups jcr:primaryType="nt:unstructured">
                             <item0 jcr:primaryType="nt:unstructured">
@@ -934,6 +935,24 @@
                             </item0>
                         </cq:styleGroups>
                     </policy_1555624447675>
+                    <policy_654210257255105
+                        jcr:lastModified="{Date}2019-09-26T15:03:52.447-07:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="WKND Article"
+                        sling:resourceType="wcm/core/components/policy/policy"
+                        clientlibs="wknd.site">
+                        <jcr:content jcr:primaryType="nt:unstructured"/>
+                    </policy_654210257255105>
+                    <policy_654239029509196
+                        jcr:lastModified="{Date}2019-09-26T15:04:18.519-07:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="WKND Experience Fragment"
+                        sling:resourceType="wcm/core/components/policy/policy"
+                        clientlibs="wknd.site">
+                        <jcr:content jcr:primaryType="nt:unstructured"/>
+                    </policy_654239029509196>
                 </page>
             </structure>
         </components>

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/policies/_rep_policy.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/policies/_rep_policy.xml
@@ -12,7 +12,7 @@
     <allow2
         jcr:primaryType="rep:GrantACE"
         rep:principalName="template-authors"
-        rep:privileges="{Name}[jcr:versionManagement,crx:replicate,rep:write,jcr:lockManagement]"/>
+        rep:privileges="{Name}[jcr:versionManagement,rep:write,crx:replicate,jcr:lockManagement]"/>
     <allow3
         jcr:primaryType="rep:GrantACE"
         rep:principalName="version-manager-service"

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/article-page-template/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/article-page-template/policies/.content.xml
@@ -2,8 +2,9 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:lastModified="{Date}2019-09-25T20:34:19.885-07:00"
+        cq:lastModified="{Date}2019-09-26T15:03:52.451-07:00"
         cq:lastModifiedBy="admin"
+        cq:policy="wknd/components/structure/page/policy_654210257255105"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/experience-fragment-web-variation-template/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/experience-fragment-web-variation-template/policies/.content.xml
@@ -2,8 +2,9 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:lastModified="{Date}2019-09-20T10:46:02.070-07:00"
+        cq:lastModified="{Date}2019-09-26T15:04:18.523-07:00"
         cq:lastModifiedBy="admin"
+        cq:policy="wknd/components/structure/page/policy_654239029509196"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/landing-page-template/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/landing-page-template/policies/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:lastModified="{Date}2019-09-20T10:11:38.292-07:00"
+        cq:lastModified="{Date}2019-09-26T15:03:19.058-07:00"
         cq:lastModifiedBy="admin"
         cq:policy="wknd/components/structure/page/policy_1555624447675"
         jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
this avoids duplicate minification in production environments (since the css/js from the ui.frontend module has already been minified)