### PR TITLE
[Image] Drag & drop SVG on image component not working

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/image/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/content/image/_cq_editConfig.xml
@@ -4,7 +4,7 @@
     <cq:dropTargets jcr:primaryType="nt:unstructured">
         <image
             jcr:primaryType="cq:DropTargetConfig"
-            accept="[image/gif,image/jpeg,image/png,image/webp,image/tiff,image/svg+xml]"
+            accept="[image/gif,image/jpeg,image/png,image/webp,image/tiff,image/svg\\+xml]"
             groups="[media]"
             propertyName="./fileReference">
             <parameters


### PR DESCRIPTION
- accepts expects a regex, escape the +

Issue surfaced in:
https://github.com/adobe/aem-core-wcm-components/issues/825, 

Fixed in:
**AEM Core Components** https://github.com/adobe/aem-core-wcm-components/pull/826
**AEM Project Archetype** https://github.com/adobe/aem-project-archetype/pull/268

This pull request addresses a solution in the WKND tutorial image proxy.