### PR TITLE
Fix/65 - Increased junit-bom dependency version to 5.5.2 to allow isolated IDE JUnit test runs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -642,7 +642,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.4.1</version>
+                <version>5.5.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
#65 - Increased junit-bom dependency version to 5.5.2 to allow isolated IDE JUnit test runs