### PR TITLE
use Java 11 compiler in Cloud Manager and set release to 11. fixes #122

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,8 +140,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <!-- Staging Maven Plugin -->
@@ -638,6 +637,38 @@ Bundle-DocURL:
                     <url>https://oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
             </distributionManagement>
+        </profile>
+        <profile>
+            <id>cm-java-11</id>
+            <activation>
+                  <property>
+                        <name>env.CM_BUILD</name>
+                  </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-toolchains-plugin</artifactId>
+                        <version>1.1</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>toolchain</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <toolchains>
+                                <jdk>
+                                    <version>1.11</version>
+                                    <vendor>oracle</vendor>
+                                </jdk>
+                            </toolchains>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
There's a couple of ways to do this, but this felt like the safest to me. With these changes, the Java _release_ will be set to 11 all the time, but the toolchains plugin will only be used when run inside Cloud Manager. The toolchains plugin configuration could also be moved into the normal build section (i.e. outside of a profile), but that's a bit more intrusive.