### PR TITLE
Bugfix/uitest packaging

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -49,6 +49,14 @@ Make sure that all issues assigned to the current milestone have been closed and
 
 2. Run the release: `mvn release:prepare` followed by `mvn release:perform`. You may need to pass `-Dgpg.passphrase=****` if your passphrase is not persisted in your `settings.xml`.
 
+> Note* for MacOS it may be necessary to include the following in your `~/.bash_profile` if you get an error like "Inappropriate ioctl for device macO"
+
+```
+GPG_TTY=$(tty)
+export GPG_TTY
+```
+
+
 3. Go to https://github.com/adobe/aem-guides-wknd/releases and edit the release tag and update the release text. Add compiled AEM Packages for AEM as a Cloud Service (default build) and special classic build for 6.x.x.
 
 4. Log into https://oss.sonatype.org/ and close the staging repository. Closing the staging repo will automatically push the artifacts to Maven Central after a small delay (4 hours for all mirrors to catch up)

--- a/ui.tests/pom.xml
+++ b/ui.tests/pom.xml
@@ -32,6 +32,7 @@
     <artifactId>aem-guides-wknd.ui.tests</artifactId>
     <name>WKND Sites Project - UI Tests</name>
     <description>UI Tests for WKND Sites Project</description>
+    <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Fix for Release error from nexus:

```
[ERROR] Rule failure while trying to close staging repository with ID "comadobeaem-1195".
[INFO] [ERROR] 
[INFO] [ERROR] Nexus Staging Rules Failure Report
[INFO] [ERROR] ==================================
[INFO] [ERROR] 
[INFO] [ERROR] Repository failures
[INFO] [ERROR]   Rule "javadoc-staging" failures
[INFO] [ERROR]     * Missing: no main jar artifact found in folder '/com/adobe/aem/guides/aem-guides-wknd.ui.tests/0.0.6'
[INFO] [ERROR]   Rule "sources-staging" failures
[INFO] [ERROR]     * Missing: no main jar artifact found in folder '/com/adobe/aem/guides/aem-guides-wknd.ui.tests/0.0.6'
```

There was no packaging type associated with the `ui.tests` module....