### PR TITLE
#148 - Relaxed specific bundle imports to support installation on 6.x 

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -152,6 +152,33 @@ Import-Package: javax.annotation;version=0.0.0,*
         </profile>
         <profile>
             <id>classic</id>
+
+             <build>
+                <plugins>
+                    <plugin>
+                       <!--================
+                        Relax AEM 6.x Dependencies to allow for broader deployment compatiblity across 6.4.x and 6.5.x
+                        ====================-->
+                        <groupId>biz.aQute.bnd</groupId>
+                        <artifactId>bnd-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <configuration>
+                                    <bnd><![CDATA[
+        Import-Package: javax.annotation;version=0.0.0, \
+                        com.day.cq.search;version="[1.3.0,2)", \
+                        com.day.cq.wcm.api;version="[1.27.0,2)", \
+                        org.apache.commons.lang3;version="[3.9.0,4)", \
+                        org.apache.sling.api.resource;version="[2.11.1,3)", \
+                        *
+                                        ]]></bnd>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+
             <dependencies>
                 <!--================
                 AEM 6.x Dependencies 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Relaxed WKND Core bundle imports to expand compatibility across various 6.4.x and 6.5.x releases.

These changes are bound to the `classic` profile, so should not affect AEM as a Cloud Service deployments whatsoever.

<!--- Describe your changes in detail -->

## Related Issue

This fixes #148 

## Motivation and Context

The prior build did not allow the WKND bundle to start on AEM 6.5.5

## How Has This Been Tested?

Tested on 6.5.5. 
This fix expands allowed dependency version ranges for the unsatisfied imports on 6.5.5 to allow the versions exported by 6.5.5. All of these adjustments are less than what was derived by 6.4.4 uberjar, but in the same Major version (so upper bounds stay the same).

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1451868/95918617-1e45e380-0d7a-11eb-8f84-6ac3e5785241.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
