### PR TITLE
downgrades maven compiler-version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>11</release>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
              <!-- Staging Maven Plugin -->


### PR DESCRIPTION

## Description

Downgrades the maven-compiler version to JDK 1.8

## Related Issue

Fix for Cloud Manager Integrated Tests issue, #153 

## Motivation and Context

Allows Stage +Production pipelines in AEM as a Cloud Service to complete

## How Has This Been Tested?

Tested locally and using AEM as a Cloud Service environments.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
