### PR TITLE
removed property on editable layout containers

### DIFF
--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/content-page/initial/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/content-page/initial/.content.xml
@@ -3,5 +3,15 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="wknd/components/page"/>
+        sling:resourceType="wknd/components/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wknd/components/container"
+            layout="responsiveGrid">
+            <container
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wknd/components/container"
+                layout="responsiveGrid"/>
+        </root>
+    </jcr:content>
 </jcr:root>

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/content-page/structure/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/content-page/structure/.content.xml
@@ -17,8 +17,7 @@
             <container
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid"/>
+                editable="{Boolean}true"/>
             <experiencefragment-footer
                 cq:styleIds="[1568592503946]"
                 jcr:primaryType="nt:unstructured"

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/empty-page/initial/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/empty-page/initial/.content.xml
@@ -3,5 +3,15 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="wknd/components/page"/>
+        sling:resourceType="wknd/components/page">
+         <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wknd/components/container"
+            layout="responsiveGrid">
+            <container
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wknd/components/container"
+                layout="responsiveGrid"/>
+        </root>
+    </jcr:content>
 </jcr:root>

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/empty-page/structure/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/empty-page/structure/.content.xml
@@ -12,8 +12,7 @@
             <container
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid"/>
+                editable="{Boolean}true"/>
         </root>
         <cq:responsive jcr:primaryType="nt:unstructured">
             <breakpoints jcr:primaryType="nt:unstructured">

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/adventure-page-template/structure/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/adventure-page-template/structure/.content.xml
@@ -25,9 +25,7 @@
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid">
-                <cq:responsive jcr:primaryType="nt:unstructured"/>
+                editable="{Boolean}true">
             </container>
             <experiencefragment-footer
                 cq:styleIds="[1568592503946]"

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/article-page-template/structure/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/article-page-template/structure/.content.xml
@@ -50,8 +50,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wknd/components/container"
-                    editable="{Boolean}true"
-                    layout="responsiveGrid">
+                    editable="{Boolean}true">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
                             jcr:primaryType="nt:unstructured"
@@ -74,8 +73,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wknd/components/container"
-                    editable="{Boolean}true"
-                    layout="responsiveGrid">
+                    editable="{Boolean}true">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
                             jcr:primaryType="nt:unstructured"

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/content-page-template/structure/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/content-page-template/structure/.content.xml
@@ -21,8 +21,7 @@
                 cq:styleIds="[1554340406437]"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid"/>
+                editable="{Boolean}true"/>
             <experiencefragment-footer
                 cq:styleIds="[1568592503946]"
                 jcr:primaryType="nt:unstructured"

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/experience-fragment-web-variation-template/structure/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/experience-fragment-web-variation-template/structure/.content.xml
@@ -20,8 +20,7 @@
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid">
+                editable="{Boolean}true">
                 <cq:responsive jcr:primaryType="nt:unstructured"/>
             </container>
         </root>

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/landing-page-template/structure/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/landing-page-template/structure/.content.xml
@@ -34,8 +34,7 @@
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid">
+                editable="{Boolean}true">
                 <cq:responsive jcr:primaryType="nt:unstructured"/>
             </container>
             <experiencefragment_1327121818

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/content-page/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/content-page/initial/.content.xml
@@ -3,5 +3,15 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="wknd/components/page"/>
+        sling:resourceType="wknd/components/page">
+        <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wknd/components/container"
+            layout="responsiveGrid">
+            <container
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wknd/components/container"
+                layout="responsiveGrid"/>
+        </root>
+    </jcr:content>
 </jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/content-page/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/content-page/structure/.content.xml
@@ -17,8 +17,7 @@
             <container
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid"/>
+                editable="{Boolean}true"/>
             <experiencefragment-footer
                 cq:styleIds="[1568592503946]"
                 jcr:primaryType="nt:unstructured"

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/empty-page/initial/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/empty-page/initial/.content.xml
@@ -3,5 +3,15 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="wknd/components/page"/>
+        sling:resourceType="wknd/components/page">
+         <root
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="wknd/components/container"
+            layout="responsiveGrid">
+            <container
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="wknd/components/container"
+                layout="responsiveGrid"/>
+        </root>
+    </jcr:content>
 </jcr:root>

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/empty-page/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/template-types/empty-page/structure/.content.xml
@@ -12,8 +12,7 @@
             <container
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid"/>
+                editable="{Boolean}true"/>
         </root>
         <cq:responsive jcr:primaryType="nt:unstructured">
             <breakpoints jcr:primaryType="nt:unstructured">

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/adventure-page-template/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/adventure-page-template/structure/.content.xml
@@ -25,9 +25,7 @@
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid">
-                <cq:responsive jcr:primaryType="nt:unstructured"/>
+                editable="{Boolean}true">
             </container>
             <experiencefragment-footer
                 cq:styleIds="[1568592503946]"

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/article-page-template/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/article-page-template/structure/.content.xml
@@ -50,8 +50,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wknd/components/container"
-                    editable="{Boolean}true"
-                    layout="responsiveGrid">
+                    editable="{Boolean}true">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
                             jcr:primaryType="nt:unstructured"
@@ -74,8 +73,7 @@
                     jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wknd/components/container"
-                    editable="{Boolean}true"
-                    layout="responsiveGrid">
+                    editable="{Boolean}true">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
                             jcr:primaryType="nt:unstructured"

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/content-page-template/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/content-page-template/structure/.content.xml
@@ -21,8 +21,7 @@
                 cq:styleIds="[1554340406437]"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid"/>
+                editable="{Boolean}true"/>
             <experiencefragment-footer
                 cq:styleIds="[1568592503946]"
                 jcr:primaryType="nt:unstructured"

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/experience-fragment-web-variation-template/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/experience-fragment-web-variation-template/structure/.content.xml
@@ -20,8 +20,7 @@
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid">
+                editable="{Boolean}true">
                 <cq:responsive jcr:primaryType="nt:unstructured"/>
             </container>
         </root>

--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/landing-page-template/structure/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/templates/landing-page-template/structure/.content.xml
@@ -34,8 +34,7 @@
                 jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wknd/components/container"
-                editable="{Boolean}true"
-                layout="responsiveGrid">
+                editable="{Boolean}true">
                 <cq:responsive jcr:primaryType="nt:unstructured"/>
             </container>
             <experiencefragment_1327121818


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes `layout="responsiveGrid"`  property on editable Layout Containers in Template Structure. This property is added in the Initial Content structure for each template, so it is redundant. It also has the negative effect of showing the Layout Container as blank in AEM 6.x.x. 

Removing this property will not effect the responsive features of the layout container(s) when editing a page created based on one of these templates.

## Related Issue

This issue fixes issue #177 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
