### PR TITLE
switched from gnu to posix

### DIFF
--- a/ui.tests/pom.xml
+++ b/ui.tests/pom.xml
@@ -95,7 +95,7 @@
                     <descriptors>
                         <descriptor>${project.basedir}/assembly-ui-test-docker-context.xml</descriptor>
                     </descriptors>
-                    <tarLongFileMode>gnu</tarLongFileMode>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes the `tarLongFileMode` in the **UI.Tests** module from `gnu` to `posix`. 

## Related Issue

Fixes for issue #195 and #189

## Motivation and Context

Some users are unable to build the ui.tests module.
