### PR TITLE
skips enforce for windows users

### DIFF
--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -155,7 +155,7 @@
                             <execution>
                                 <id>enforce-checksum-of-immutable-files</id>
                                 <goals>
-                                    <goal>enforce</goal>
+                                    <goal>display-info</goal>
                                 </goals>
                                 <configuration>
                                     <rules>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Skips Dispatcher enforcement plugin for users on windows environments.

## Related Issue

Fixes for issue #201 and #179 

## Motivation and Context

Some Windows users experience a Maven enforcer issue where it appears that default dispatcher files have been modified. Unclear if this is a result of differences between Mac and Windows or something that occurs during the checkout process. Most users simply want to install the code base to a local environment and this check is unnecessary. Removing the enforcement for windows builds.
