### PR TITLE
fixes incorrect path

### DIFF
--- a/ui.content.sample/src/main/content/jcr_root/content/experience-fragments/wknd/language-masters/en/site/header/master/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/content/experience-fragments/wknd/language-masters/en/site/header/master/.content.xml
@@ -148,7 +148,7 @@
                         jcr:lastModifiedBy="admin"
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="wknd/components/search"
-                        searchRoot="/content/wknd/en">
+                        searchRoot="/content/wknd/language-masters/en">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
                                 jcr:primaryType="nt:unstructured"

--- a/ui.content/src/main/content/jcr_root/content/experience-fragments/wknd/language-masters/en/site/header/master/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/experience-fragments/wknd/language-masters/en/site/header/master/.content.xml
@@ -148,7 +148,7 @@
                         jcr:lastModifiedBy="admin"
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="wknd/components/search"
-                        searchRoot="/content/wknd/en">
+                        searchRoot="/content/wknd/language-masters/en">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
                                 jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the Search path for the Quick Search component as part of the Experience Fragment. 

## Related Issue

Fix for issue #215 

## Motivation and Context

The current path did not point to a valid page and thus the component defaulted to searching beneath the current page only. This update points to a valid Language Master page and thus will also be localized appropriately for the language structure.

## How Has This Been Tested?

Tested locally and on AEM as a Cloud Service.

Resolves correctly for multi-lingual sites. For example if you search for "Hiking" within the Canadian / English site only search results within `ca/en` will be returned.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/8974514/114625461-261e0c00-9c67-11eb-9507-c38e91930157.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
