### PR TITLE
#220 Add CDN optimized Cache-Control headers

### DIFF
--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -36,8 +36,6 @@ Include conf.d/variables/custom.vars
 		SetOutputFilter DEFLATE
 		# Don't compress images
 		SetEnvIfNoCase Request_URI \.(?:gif|jpe?g|png)$ no-gzip dont-vary
-		# Make sure proxies don't deliver the wrong content
-		Header append Vary User-Agent env=!dont-vary
 		# Prevent clickjacking
 		Header always append X-Frame-Options SAMEORIGIN
 	</Directory>
@@ -60,5 +58,20 @@ Include conf.d/variables/custom.vars
     ErrorDocument 502 ${500_PAGE}
     ErrorDocument 503 ${500_PAGE}
     ErrorDocument 504 ${500_PAGE}
-
+    # AEM Theme Sources: cache mutable (but very likely not changed) resources for 24h on CDN and background refresh to avoid MISS on CDN
+    <LocationMatch "^/etc\.clientlibs/.*\.(?i:json|png|gif|jpe?g)$">
+        Header set Cache-Control "max-age=7200,s-maxage=86400,stale-while-revalidate=43200,stale-if-error=43200,public"
+    </LocationMatch>
+    # AEM Theme Sources: cache immutable resources for 1year (as recommended by Lighthouse), background refresh to avoid MISS on CDN
+    <LocationMatch "^/etc\.clientlibs/.*\.(?i:js|css|ttf|svg)$">
+        Header set Cache-Control "max-age=31536000,stale-while-revalidate=43200,stale-if-error=43200,public,immutable"
+    </LocationMatch>
+    # HTML pages: CDN cache for 10min with background refresh to avoid MISS on CDN
+    <LocationMatch "\.html$">
+        Header set Cache-Control "max-age=60,s-maxage=600,stale-while-revalidate=43200,stale-if-error=43200"
+    </LocationMatch>
+    # Core Component Image Component has immutable URLs, cache for 1year (as recommended by Lighthouse), background refresh to avoid MISS on CDN
+    <LocationMatch "\.coreimg\..*\.(?i:jpe?g|png|gif|svg)$">
+        Header set Cache-Control "max-age=31536000,stale-while-revalidate=43200,stale-if-error=43200,public,immutable"
+    </LocationMatch>
 </VirtualHost>

--- a/dispatcher/src/conf.d/rewrites/rewrite.rules
+++ b/dispatcher/src/conf.d/rewrites/rewrite.rules
@@ -7,13 +7,16 @@
 
 Include conf.d/rewrites/default_rewrite.rules
 
+# make sure the root site redirects are cache on CDN to avoid origin round-trip
+Header always set Cache-Control "max-age=60,s-maxage=600,stale-while-revalidate=43200,stale-if-error=43200" env=cdncache
+
 # redirect traffic from www to http home page
 RewriteCond %{HTTP_HOST} www.wknd.site [NC]
-RewriteRule ^(.*)$ https://wknd.site%{REQUEST_URI} [R=301,L]
+RewriteRule ^(.*)$ https://wknd.site%{REQUEST_URI} [R=301,L,E=cdncache]
 
 # redirect all root traffic to US home page
 RewriteCond %{REQUEST_URI} ^/?$
-RewriteRule ^(/)$ /us/en.html [R=301,L]
+RewriteRule ^(/)$ /us/en.html [R=301,L,E=cdncache]
 
 RewriteCond %{REQUEST_URI} !^/apps
 RewriteCond %{REQUEST_URI} !^/bin


### PR DESCRIPTION
AEM as a Cloud Services comes with CDN per default. The default headers of AEM, as of April 2021, do not optimize cache-hit-ratio with the CDN, and therefore accelerate the site experience. This patch adds httpd config to add extra headers.

## Description

1. Removing the User-Agent from the vary header, that is fragmenting the CDN cache
2. Add headers for resources optimized based on resource type (mutable vs immutable)
3. Add headers to base root redirects to avoid origin requests 

