### PR TITLE
Avoid 302 redirects for Image List

### DIFF
--- a/core/src/main/java/com/adobe/aem/guides/wknd/core/models/impl/ImageListImpl.java
+++ b/core/src/main/java/com/adobe/aem/guides/wknd/core/models/impl/ImageListImpl.java
@@ -157,7 +157,7 @@ public class ImageListImpl implements ImageList {
             final PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
             this.wrappedListItem = listItem;
             this.parentId = parentId;
-            this.page = pageManager.getContainingPage(wrappedListItem.getPath());          
+            this.page = pageManager.getContainingPage(wrappedListItem.getPath());
 
             image = findPageComponentResources(this.page, IMAGE_RESOURCE_TYPE, 1).stream()
                     .map(r -> new SimpleImageComponentResource(r, getTitle()))
@@ -280,15 +280,15 @@ public class ImageListImpl implements ImageList {
         public SimpleImageComponentResource(final Resource resource, final String alt) {
             super(resource);
 
-            // Expose the original fileReference
-            properties.put(PN_FILE_REFERENCE,
-                    resource.getValueMap().get(PN_FILE_REFERENCE));
+            // Copy the properties from the original image
+            properties.putAll(resource.getValueMap());
 
             // Override the decorative configuration attributes
             properties.put(PN_ALT, alt);
             properties.put(Image.PN_IS_DECORATIVE, false);
-            properties.put(Image.PN_DISPLAY_POPUP_TITLE, false);
+            properties.put(Image.PN_DISPLAY_POPUP_TITLE, true);
             properties.put(Image.PN_TITLE_VALUE_FROM_DAM, false);
+            properties.put(Image.PN_ALT_VALUE_FROM_DAM, false);
         }
 
         @Override

--- a/core/src/test/java/com/adobe/aem/guides/wknd/core/models/impl/ImageListImplTest.java
+++ b/core/src/test/java/com/adobe/aem/guides/wknd/core/models/impl/ImageListImplTest.java
@@ -156,12 +156,13 @@ class ImageListImplTest {
 
         final ValueMap actual = new ImageListImpl.SimpleImageComponentResource(imageResource, "Test alt text").getValueMap();
 
-        assertEquals(5, actual.values().size());
+        assertEquals(8, actual.values().size());
         assertEquals("/content/dam/test.png", actual.get("fileReference"));
         assertEquals("Test alt text", actual.get("alt"));
         assertEquals(false, actual.get(Image.PN_IS_DECORATIVE));
-        assertEquals(false, actual.get(Image.PN_DISPLAY_POPUP_TITLE));
+        assertEquals(true, actual.get(Image.PN_DISPLAY_POPUP_TITLE));
         assertEquals(false, actual.get(Image.PN_TITLE_VALUE_FROM_DAM));
+        assertEquals(false, actual.get(Image.PN_ALT_VALUE_FROM_DAM));
     }
 
     @Test
@@ -170,12 +171,13 @@ class ImageListImplTest {
 
         final ValueMap actual = new ImageListImpl.SimpleImageComponentResource(imageResource, "Test alt text").adaptTo(ValueMap.class);
 
-        assertEquals(5, actual.values().size());
+        assertEquals(8, actual.values().size());
         assertEquals("/content/dam/test.png", actual.get("fileReference"));
         assertEquals("Test alt text", actual.get("alt"));
         assertEquals(false, actual.get(Image.PN_IS_DECORATIVE));
-        assertEquals(false, actual.get(Image.PN_DISPLAY_POPUP_TITLE));
+        assertEquals(true, actual.get(Image.PN_DISPLAY_POPUP_TITLE));
         assertEquals(false, actual.get(Image.PN_TITLE_VALUE_FROM_DAM));
+        assertEquals(false, actual.get(Image.PN_ALT_VALUE_FROM_DAM));
     }
 
 
@@ -191,7 +193,7 @@ class ImageListImplTest {
 
     @Test
     void getData() throws RepositoryException, IllegalAccessException, NoSuchFieldException {
-    	
+
    	 	// Page 1
         Resource page1ImageComponentResource = spy(ctx.resourceResolver().getResource("/content/pages/page-1/jcr:content/root/responsivegrid/page-1-image-component"));
         doReturn(leakedResourceResolver).when(page1ImageComponentResource).getResourceResolver();
@@ -205,19 +207,19 @@ class ImageListImplTest {
         ctx.currentResource("/content/image-list");
 
         final ImageList actual = ctx.request().adaptTo(ImageList.class);
-        
+
         setCoreList((ImageListImpl) actual, new MockList("/content/pages/page-1"));
 
         ImageList.ListItem[] actualListItems = actual.getListItems().toArray(new ImageList.ListItem[0]);
-        
+
         //Test Data Layer on Image List (parent)
         assertNotNull(actual.getData());
         assertEquals("wknd/components/image-list", actual.getData().getType());
         assertEquals("image-list-2719473ca4", actual.getData().getId());
-        
+
         //Test Data Layer on Image List Items
         ComponentData listItemData = actualListItems[0].getData();
-        
+
         assertNotNull(listItemData);
         assertEquals("wknd/components/image-list/image-list-item", listItemData.getType());
         assertEquals("image-list-2719473ca4-image-list-item-58adf87daa", actualListItems[0].getData().getId());
@@ -226,10 +228,10 @@ class ImageListImplTest {
         assertEquals("/content/pages/page-1.html", listItemData.getLinkUrl());
         assertEquals("image-list-2719473ca4", listItemData.getParentId());
     }
-    
+
     @Test
     void getData_disabled() throws RepositoryException, IllegalAccessException, NoSuchFieldException {
-    	
+
     	// Page 1
         Resource page1ImageComponentResource = spy(ctx.resourceResolver().getResource("/content/pages/page-1/jcr:content/root/responsivegrid/page-1-image-component"));
         doReturn(leakedResourceResolver).when(page1ImageComponentResource).getResourceResolver();
@@ -240,20 +242,19 @@ class ImageListImplTest {
 
         //Disable the data layer
         enableDataLayer(ctx, false);
-        
+
         ctx.currentResource("/content/image-list");
 
         final ImageList actual = ctx.request().adaptTo(ImageList.class);
         assertNull(actual.getData());
-        
+
         setCoreList((ImageListImpl) actual, new MockList("/content/pages/page-1"));
 
         ImageList.ListItem[] actualListItems = actual.getListItems().toArray(new ImageList.ListItem[2]);
-        
+
         //Test Data Layer on Image List Items
         assertNull(actualListItems[0].getData());
-        
-        
+
     }
 
     /**

--- a/core/src/test/java/com/adobe/aem/guides/wknd/core/models/impl/ImageListImplTest.java
+++ b/core/src/test/java/com/adobe/aem/guides/wknd/core/models/impl/ImageListImplTest.java
@@ -21,6 +21,7 @@ import com.adobe.cq.wcm.core.components.models.Image;
 import com.adobe.cq.wcm.core.components.models.List;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.models.datalayer.ComponentData;
+import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.search.PredicateGroup;
 import com.day.cq.search.Query;
 import com.day.cq.search.QueryBuilder;
@@ -45,6 +46,7 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -156,13 +158,17 @@ class ImageListImplTest {
 
         final ValueMap actual = new ImageListImpl.SimpleImageComponentResource(imageResource, "Test alt text").getValueMap();
 
-        assertEquals(8, actual.values().size());
+        assertEquals(9, actual.values().size());
         assertEquals("/content/dam/test.png", actual.get("fileReference"));
         assertEquals("Test alt text", actual.get("alt"));
         assertEquals(false, actual.get(Image.PN_IS_DECORATIVE));
         assertEquals(true, actual.get(Image.PN_DISPLAY_POPUP_TITLE));
         assertEquals(false, actual.get(Image.PN_TITLE_VALUE_FROM_DAM));
         assertEquals(false, actual.get(Image.PN_ALT_VALUE_FROM_DAM));
+
+        // validate lastModified time in milliseconds
+        Calendar actualLastModified = actual.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
+        assertEquals(1569508227169L, actualLastModified.getTimeInMillis());
     }
 
     @Test
@@ -171,13 +177,17 @@ class ImageListImplTest {
 
         final ValueMap actual = new ImageListImpl.SimpleImageComponentResource(imageResource, "Test alt text").adaptTo(ValueMap.class);
 
-        assertEquals(8, actual.values().size());
+        assertEquals(9, actual.values().size());
         assertEquals("/content/dam/test.png", actual.get("fileReference"));
         assertEquals("Test alt text", actual.get("alt"));
         assertEquals(false, actual.get(Image.PN_IS_DECORATIVE));
         assertEquals(true, actual.get(Image.PN_DISPLAY_POPUP_TITLE));
         assertEquals(false, actual.get(Image.PN_TITLE_VALUE_FROM_DAM));
         assertEquals(false, actual.get(Image.PN_ALT_VALUE_FROM_DAM));
+
+        // validate lastModified time in milliseconds
+        Calendar actualLastModified = actual.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
+        assertEquals(1569508227169L, actualLastModified.getTimeInMillis());
     }
 
 

--- a/core/src/test/resources/com/adobe/aem/guides/wknd/core/models/impl/ImageListImplTest.json
+++ b/core/src/test/resources/com/adobe/aem/guides/wknd/core/models/impl/ImageListImplTest.json
@@ -65,6 +65,7 @@
     "fileReference": "/content/dam/test.png",
     "alt": "Wrapped alt",
     "altValueFromDAM": "true",
-    "displayPopupTitle": "false"
+    "displayPopupTitle": "false",
+    "jcr:lastModified": "2019-09-26T07:30:27.169-07:00"
   }
 }

--- a/core/src/test/resources/com/adobe/aem/guides/wknd/core/models/impl/ImageListImplTest.json
+++ b/core/src/test/resources/com/adobe/aem/guides/wknd/core/models/impl/ImageListImplTest.json
@@ -63,6 +63,8 @@
     "jcr:primaryType": "nt:unstructured",
     "sling:resourceType": "wknd/components/image",
     "fileReference": "/content/dam/test.png",
-    "alt": "Wrapped alt"
+    "alt": "Wrapped alt",
+    "altValueFromDAM": "true",
+    "displayPopupTitle": "false"
   }
 }

--- a/ui.frontend/src/main/webpack/components/image-list/scss/styles/_default.scss
+++ b/ui.frontend/src/main/webpack/components/image-list/scss/styles/_default.scss
@@ -70,6 +70,10 @@
     }
   }
 
+  .cmp-image__title {
+      display: none;
+  }
+
   @media (max-width: $screen-small) {
     justify-content: space-between;
 
@@ -77,5 +81,5 @@
       padding-right:0;
     }
   }
-  
+
 }

--- a/ui.frontend/src/main/webpack/components/image-list/scss/styles/_default.scss
+++ b/ui.frontend/src/main/webpack/components/image-list/scss/styles/_default.scss
@@ -70,10 +70,6 @@
     }
   }
 
-  .cmp-image__title {
-      display: none;
-  }
-
   @media (max-width: $screen-small) {
     justify-content: space-between;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wraps all of the original properties of the referenced image. This includes the timestamp which will make sure that caching/updates to the underlying image behave as expected.

## Related Issue

Fixes #218 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
