### PR TITLE
Update frontend-maven-plugin for project to build on Macs with M1 chip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
                 <plugin>
                     <groupId>com.github.eirslett</groupId>
                     <artifactId>frontend-maven-plugin</artifactId>
-                    <version>1.7.6</version>
+                    <version>1.11.3</version>
                     <configuration>
                         <nodeVersion>v10.13.0</nodeVersion>
                         <npmVersion>6.9.0</npmVersion>

--- a/ui.tests/pom.xml
+++ b/ui.tests/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <frontend-maven-plugin.version>1.7.6</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>1.11.3</frontend-maven-plugin.version>
         <node.version>v12.16.3</node.version>
         <npm.version>6.14.4</npm.version>
 


### PR DESCRIPTION
Building this project on a MacOS computer with an Apple M1 chip fails because of the frontend-maven-plugin not supporting it in older versions of that plugin. Therefore updating the frontend-maven-plugin to 1.11.3.

See related change in the frontend-maven-plugin that adds support arm64 binaries:
https://github.com/eirslett/frontend-maven-plugin/pull/970

## How Has This Been Tested?

Now builds on my machine… didn't test on another machine though.
I've also updated the dependency in the `ui.tests` project.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
