### PR TITLE
Issue 245/cm code quality

### DIFF
--- a/core/src/main/java/com/adobe/aem/guides/wknd/core/models/HelloWorldModel.java
+++ b/core/src/main/java/com/adobe/aem/guides/wknd/core/models/HelloWorldModel.java
@@ -24,10 +24,8 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
-import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
-import org.apache.sling.settings.SlingSettingsService;
 
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
@@ -41,8 +39,6 @@ public class HelloWorldModel {
     @Default(values="No resourceType")
     protected String resourceType;
 
-    @OSGiService
-    private SlingSettingsService settings;
     @SlingObject
     private Resource currentResource;
     @SlingObject
@@ -59,8 +55,7 @@ public class HelloWorldModel {
 
         message = "Hello World!\n"
             + "Resource type is: " + resourceType + "\n"
-            + "Current page is:  " + currentPagePath + "\n"
-            + "This is instance: " + settings.getSlingId() + "\n";
+            + "Current page is:  " + currentPagePath + "\n";
     }
 
     public String getMessage() {

--- a/ui.apps/src/main/content/META-INF/vault/filter.xml
+++ b/ui.apps/src/main/content/META-INF/vault/filter.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-    <filter root="/apps/wknd"/>
+    <filter root="/apps/wknd/clientlibs"/>
+    <filter root="/apps/wknd/components"/>
+    <filter root="/apps/wknd/i18n"/>
     <filter root="/apps/msm/wknd_blueprint" mode="merge"/>
 </workspaceFilter>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/image/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/image/_cq_editConfig.xml
@@ -19,7 +19,7 @@
         jcr:primaryType="cq:InplaceEditingConfig"
         active="{Boolean}true"
         editorType="image">
-        <config jcr:primaryType="nt:unstructured">
+        <inplaceEditingConfig jcr:primaryType="nt:unstructured">
             <plugins jcr:primaryType="nt:unstructured">
                 <crop
                     jcr:primaryType="nt:unstructured"
@@ -86,6 +86,6 @@
                     </replacementToolbars>
                 </fullscreen>
             </ui>
-        </config>
+        </inplaceEditingConfig>
     </cq:inplaceEditing>
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/text/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/text/_cq_editConfig.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="cq:EditConfig">
+    <cq:inplaceEditing
+        jcr:primaryType="cq:InplaceEditingConfig"
+        active="{Boolean}true"
+        configPath="inplaceEditingConfig"
+        editorType="text">
+        <inplaceEditingConfig jcr:primaryType="nt:unstructured">
+            <rtePlugins jcr:primaryType="nt:unstructured">
+                <tracklinks
+                    jcr:primaryType="nt:unstructured"
+                    features="*"/>
+                <table
+                    jcr:primaryType="nt:unstructured"
+                    features="-">
+                    <hiddenHeaderConfig
+                        jcr:primaryType="nt:unstructured"
+                        hiddenHeaderClassName="cq-wcm-foundation-aria-visuallyhidden"/>
+                </table>
+                <paraformat jcr:primaryType="nt:unstructured">
+                    <formats jcr:primaryType="nt:unstructured">
+                        <default_p
+                            jcr:primaryType="nt:unstructured"
+                            description="Paragraph"
+                            tag="p"/>
+                        <default_h1
+                            jcr:primaryType="nt:unstructured"
+                            description="Heading 1"
+                            tag="h1"/>
+                        <default_h2
+                            jcr:primaryType="nt:unstructured"
+                            description="Heading 2"
+                            tag="h2"/>
+                        <default_h3
+                            jcr:primaryType="nt:unstructured"
+                            description="Heading 3"
+                            tag="h3"/>
+                        <default_h4
+                            jcr:primaryType="nt:unstructured"
+                            description="Heading 4"
+                            tag="h4"/>
+                        <default_h5
+                            jcr:primaryType="nt:unstructured"
+                            description="Heading 5"
+                            tag="h5"/>
+                        <default_h6
+                            jcr:primaryType="nt:unstructured"
+                            description="Heading 6"
+                            tag="h6"/>
+                        <default_blockquote
+                            jcr:primaryType="nt:unstructured"
+                            description="Quote"
+                            tag="blockquote"/>
+                        <default_hr
+                            jcr:primaryType="nt:unstructured"
+                            description="Horizontal Rule (visual line break)"
+                            tag="hr"/>
+                        <default_pre
+                            jcr:primaryType="nt:unstructured"
+                            description="Preformatted"
+                            tag="pre"/>
+                    </formats>
+                </paraformat>
+                <misctools jcr:primaryType="nt:unstructured">
+                    <specialCharsConfig jcr:primaryType="nt:unstructured">
+                        <chars jcr:primaryType="nt:unstructured">
+                            <default_copyright
+                                jcr:primaryType="nt:unstructured"
+                                entity="&amp;copy;"
+                                name="copyright"/>
+                            <default_euro
+                                jcr:primaryType="nt:unstructured"
+                                entity="&amp;euro;"
+                                name="euro"/>
+                            <default_registered
+                                jcr:primaryType="nt:unstructured"
+                                entity="&amp;reg;"
+                                name="registered"/>
+                            <default_trademark
+                                jcr:primaryType="nt:unstructured"
+                                entity="&amp;trade;"
+                                name="trademark"/>
+                        </chars>
+                    </specialCharsConfig>
+                </misctools>
+                <links
+                    jcr:primaryType="nt:unstructured"
+                    features="modifylink,unlink"/>
+                <justify
+                    jcr:primaryType="nt:unstructured"
+                    features="-"/>
+                <format
+                    jcr:primaryType="nt:unstructured"
+                    features="bold,italic"/>
+            </rtePlugins>
+            <uiSettings jcr:primaryType="nt:unstructured">
+                <cui jcr:primaryType="nt:unstructured">
+                    <inline
+                        jcr:primaryType="nt:unstructured"
+                        toolbar="[#format,#justify,#lists,links#modifylink,links#unlink,#paraformat,fullscreen#start,control#close,control#save]">
+                        <popovers jcr:primaryType="nt:unstructured">
+                            <format
+                                jcr:primaryType="nt:unstructured"
+                                items="[format#bold,format#italic,format#underline]"
+                                ref="format"/>
+                            <justify
+                                jcr:primaryType="nt:unstructured"
+                                items="[justify#justifyleft,justify#justifycenter,justify#justifyright,justify#justifyjustify]"
+                                ref="justify"/>
+                            <lists
+                                jcr:primaryType="nt:unstructured"
+                                items="[lists#unordered,lists#ordered,lists#outdent,lists#indent]"
+                                ref="lists"/>
+                            <paraformat
+                                jcr:primaryType="nt:unstructured"
+                                items="paraformat:getFormats:paraformat-pulldown"
+                                ref="paraformat"/>
+                        </popovers>
+                    </inline>
+                </cui>
+            </uiSettings>
+        </inplaceEditingConfig>
+    </cq:inplaceEditing>
+</jcr:root>

--- a/ui.content.sample/pom.xml
+++ b/ui.content.sample/pom.xml
@@ -58,7 +58,7 @@
                         </jackrabbit-nodetypes>
                         <jackrabbit-filter>
                             <options>
-                                <validRoots>/conf,/content,/content/experience-fragments,/content/dam</validRoots>
+                                <validRoots>/conf,/content,/content/experience-fragments,/content/dam,/content/cq:tags,/home/groups,/home/users</validRoots>
                             </options>
                         </jackrabbit-filter>
                     </validatorsSettings>

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/.content.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="sling:Folder"
-    jcr:title="WKND Site"/>

--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/.content.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="sling:Folder"/>

--- a/ui.content.sample/src/main/content/jcr_root/content/dam/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/content/dam/.content.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:rep="internal"
-    jcr:mixinTypes="[mix:lockable,rep:AccessControllable]"
-    jcr:primaryType="sling:OrderedFolder">
-    <rep:policy/>
-    <__contentFolderName__/>
-</jcr:root>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -58,7 +58,7 @@
                         </jackrabbit-nodetypes>
                         <jackrabbit-filter>
                             <options>
-                                <validRoots>/conf,/content,/content/experience-fragments,/content/dam</validRoots>
+                                <validRoots>/conf,/content,/content/experience-fragments,/content/dam,/content/cq:tags</validRoots>
                             </options>
                         </jackrabbit-filter>
                     </validatorsSettings>

--- a/ui.content/src/main/content/jcr_root/content/dam/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/dam/.content.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:rep="internal"
-    jcr:mixinTypes="[mix:lockable,rep:AccessControllable]"
-    jcr:primaryType="sling:OrderedFolder">
-    <rep:policy/>
-    <__contentFolderName__/>
-</jcr:root>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes for several warnings triggered in Cloud Manager:

Package | Line Number | Issue
-- | -- | --
com.adobe.aem.guides:aem-guides-wknd.ui.apps:0.3.1-SNAPSHOT | 0 | Node /apps/wknd/components/image/cq:editConfig/cq:inplaceEditing/config   is an OSGi config or install path which contains non-OSGi-related children   that will not be visible to non-administrative users.
com.adobe.aem.guides:aem-guides-wknd.ui.config:0.3.1-SNAPSHOT | 0 | affected path /apps/wknd/osgiconfig overlaps   [com.adobe.aem.guides:aem-guides-wknd.ui.apps:0.3.1-SNAPSHOT]
com.adobe.aem.guides:aem-guides-wknd.core:src/main/java/com/adobe/aem/guides/wknd/core/models/HelloWorldModel.java | 30 | The class or interface org.apache.sling.settings.SlingSettingsService has   been deprecated and is not recommended to be used on AEM.
com.adobe.aem.guides:aem-guides-wknd.core:src/main/java/com/adobe/aem/guides/wknd/core/models/HelloWorldModel.java | 45 | Remove this use of "SlingSettingsService"; it is deprecated.

## Related Issue

Originally filed as issue #245 


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
