### PR TITLE
Fix Enable WKND GraphQL Endpoint

### DIFF
--- a/dispatcher/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/filters.any
@@ -21,6 +21,7 @@ $include "./default_filters.any"
 # Allow GraphQL global endpoint & preflight requests
 # GraphQL also supports GET requests, if you intend to use GET include it in the rule below
 /0164 { /type "allow" /method '(POST|OPTIONS)' /url "/content/graphql/global/endpoint.json" /extension "json"}
+/0165 { /type "allow" /method '(POST|OPTIONS)' /url "/content/cq:graphql/wknd/endpoint.json" /extension "json"}
 
 # GraphQL Persisted Queries
 /0170 { /type "allow" /method '(POST|OPTIONS)' /url "/graphql/execute.json/*" }

--- a/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.author/com.adobe.granite.cors.impl.CORSPolicyImpl~wknd-graphql.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.author/com.adobe.granite.cors.impl.CORSPolicyImpl~wknd-graphql.cfg.json
@@ -17,7 +17,8 @@
     "http://localhost:.*"
   ],
   "allowedpaths":[
-    "/content/graphql/global/endpoint.json"
+    "/content/graphql/global/endpoint.json",
+    "/content/cq:graphql/wknd/endpoint.json"
   ],
   "supportedheaders":[
     "Origin",

--- a/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.author/com.adobe.granite.csrf.impl.CSRFFilter.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.author/com.adobe.granite.csrf.impl.CSRFFilter.cfg.json
@@ -14,7 +14,8 @@
   "filter.excluded.paths":[
     "/libs/dam/gui/content/assets/assetlinkshare",
     "/content/communities/scorm/RecordResults",
-    "/content/cq:graphql/global/endpoint"
+    "/content/cq:graphql/global/endpoint",
+    "/content/cq:graphql/wknd/endpoint"
   ],
   "filter.methods":[
     "POST",

--- a/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish/com.adobe.granite.cors.impl.CORSPolicyImpl~wknd-graphql.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish/com.adobe.granite.cors.impl.CORSPolicyImpl~wknd-graphql.cfg.json
@@ -17,7 +17,8 @@
     "http://localhost:.*"
   ],
   "allowedpaths":[
-    "/content/graphql/global/endpoint.json"
+    "/content/graphql/global/endpoint.json",
+    "/content/cq:graphql/wknd/endpoint.json"
   ],
   "supportedheaders":[
     "Origin",

--- a/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish/com.adobe.granite.csrf.impl.CSRFFilter.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish/com.adobe.granite.csrf.impl.CSRFFilter.cfg.json
@@ -14,7 +14,8 @@
   "filter.excluded.paths":[
     "/libs/dam/gui/content/assets/assetlinkshare",
     "/content/communities/scorm/RecordResults",
-    "/content/cq:graphql/global/endpoint"
+    "/content/cq:graphql/global/endpoint",
+    "/content/cq:graphql/wknd/endpoint"
   ],
   "filter.methods":[
     "POST",

--- a/ui.content/src/main/content/jcr_root/content/_cq_graphql/wknd/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/_cq_graphql/wknd/.content.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    cq:conf="/conf/global/settings/dam/cfm/models"
     jcr:primaryType="sling:Folder"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This includes additional configurations to enable the WKND GraphQL endpoint at `/content/cq:graphql/wknd/endpoint.json`

- Updates CORS config
- Updates CRSFFilter config
- Updates dispatcher
- Removes unnecessary property on wknd endpoint

## Related Issue

Related to issue #248

## Motivation and Context

If a WKND specific endpoint is needed to enable persistent queries, we should also open the wknd specific endpoint to traffic. This will allow users to compare queries against: 

`/content/graphql/global/endpoint.json` vs. `/content/cq:graphql/wknd/endpoint.json`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
