### PR TITLE
Archetype 28's immutable files update from Dispatcher SDK 2.0.60

### DIFF
--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -101,7 +101,7 @@
                                         </requireFileChecksum>
                                         <requireFileChecksum>
                                             <file>src/conf.dispatcher.d/clientheaders/default_clientheaders.any</file>
-                                            <checksum>3e419094a9eb5baf46bb690934447312</checksum>
+                                            <checksum>b9b4548f5570cffe7a7f10ffb219e27e</checksum>
                                             <type>md5</type>
                                             <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/clientheaders/default_clientheaders.any</message>
                                         </requireFileChecksum>
@@ -113,7 +113,7 @@
                                         </requireFileChecksum>
                                         <requireFileChecksum>
                                             <file>src/conf.dispatcher.d/filters/default_filters.any</file>
-                                            <checksum>92062b7079910ae4bcaca24d9260bc7e</checksum>
+                                            <checksum>9ec99c914a961bbbab406218f8c1fb51</checksum>
                                             <type>md5</type>
                                             <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/filters/default_filters.any</message>
                                         </requireFileChecksum>
@@ -198,7 +198,7 @@
                                         </requireFileChecksum>
                                         <requireFileChecksum>
                                             <file>src/conf.dispatcher.d/clientheaders/default_clientheaders.any</file>
-                                            <checksum>419aec8dd840407559fba09d24cc70db</checksum>
+                                            <checksum>acfa31c74c1a34d8e30658a09358f8d7</checksum>
                                             <type>md5</type>
                                             <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/clientheaders/default_clientheaders.any</message>
                                         </requireFileChecksum>
@@ -210,7 +210,7 @@
                                         </requireFileChecksum>
                                         <requireFileChecksum>
                                             <file>src/conf.dispatcher.d/filters/default_filters.any</file>
-                                            <checksum>e9d0454714b1ba1cf86bf5ba7e86d316</checksum>
+                                            <checksum>70e31f0d18a9656075f928ee108aa366</checksum>
                                             <type>md5</type>
                                             <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/filters/default_filters.any</message>
                                         </requireFileChecksum>

--- a/dispatcher/src/conf.dispatcher.d/clientheaders/default_clientheaders.any
+++ b/dispatcher/src/conf.dispatcher.d/clientheaders/default_clientheaders.any
@@ -40,3 +40,4 @@
 "Sling-uploadmode"
 "x-requested-with"
 "If-Modified-Since"
+"Authorization"

--- a/dispatcher/src/conf.dispatcher.d/filters/default_filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/default_filters.any
@@ -52,7 +52,7 @@
 
 # AEM Forms specific filters
 # to allow AF specific endpoints for prefill, submit and sign
-/0032 { /type "allow" /path "/content/forms/af/*" /method "POST" /selectors '(submit|internalsubmit|agreement|signSubmit|prefilldata)' /extension '(jsp|json)' }
+/0032 { /type "allow" /path "/content/forms/af/*" /method "POST" /selectors '(submit|internalsubmit|agreement|signSubmit|prefilldata|save)' /extension '(jsp|json)' }
 
 # to allow AF specific endpoints for thank you page
 /0033 { /type "allow" /path "/content/forms/af/*"  /method "GET" /selectors '(guideThankYouPage|guideAsyncThankYouPage)'  /extension '(html)'}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Archetype 28's immutable files update from Dispatcher SDK 2.0.60

## Related Issue

Follow up on #259 #247 #246

## Motivation and Context

Immutable dispatcher configuration files should be in sync with contemporary Dispatcher SDK (currently 2.0.60) and Archetype project.

## How Has This Been Tested?

Make diff between dispatcher subproject's src directories between WKND and Archetype.
_mvn clean install_ in both dispatcher subproject and in the root directory

## Screenshots (if appropriate):

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
