### PR TITLE
CORS headers pass through to the publish

### DIFF
--- a/dispatcher/src/conf.dispatcher.d/clientheaders/clientheaders.any
+++ b/dispatcher/src/conf.dispatcher.d/clientheaders/clientheaders.any
@@ -4,4 +4,10 @@
 # By default, it includes the default client headers.
 #
 
+# Allowing CORS headers to be passed through to the publish tier to support headless and SPA Editor use cases.
+
+"access-control-request-headers"
+"access-control-request-method"
+"origin"
+
 $include "./default_clientheaders.any"


### PR DESCRIPTION
As the dispatcher config filters out CORS headers from the pre-flight requests the CORS validation fails on publish instances when using the WKND example together with the SPA Editor or in headless scenarios.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
