### PR TITLE
Fix/277 - Fixes issues with the iPad Retina's Emulator's Layout mode not being reflected

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-grid/less/grid.less
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-grid/less/grid.less
@@ -18,7 +18,7 @@
 
  /* maximum amount of grid cells to be provided */
  @max_col: 12;
- @screen-small: 767px;
+ @screen-small: 768px;
  @screen-medium: 1024px;
  @screen-large: 1200px;
  @gutter-padding: 14px;

--- a/ui.content/src/main/content/jcr_root/content/experience-fragments/wknd/language-masters/en/site/header/master/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/experience-fragments/wknd/language-masters/en/site/header/master/.content.xml
@@ -138,6 +138,9 @@
                             <tablet
                                 jcr:primaryType="nt:unstructured"
                                 behavior="hide"/>
+                            <phone
+                                jcr:primaryType="nt:unstructured"
+                                behavior="hide"/>                                
                         </cq:responsive>
                     </navigation>
                     <search


### PR DESCRIPTION
(767px -> 768px -- as the cq:responsive breakpoint is set to 768)
https://experienceleague.adobe.com/docs/experience-manager-64/administering/operations/configuring-responsive-layout.html?lang=en

<!--- Provide a general summary of your changes in the Title above -->

## Description

When selecting the iPad Retina emulator in Layout Mode in PageEditor (which is width 768px) layout mode does not work (it snaps back).

The reason for this is as follows:

+ In WKND grid.less, there "phone" breakpoint had a max-width of 767px.
+ The WKND's templates cq:responsive breakpoint for "phone" had a width of 768px.
+ The iPad Retina emulator has a width of 768px

So, when iPad Retina emulator is selected, the "phone" breakpoint is resolved, and the Layout changes are persisted to the component's `cq:responsive/phone` node (since iPad Retina's 768px <= Template's cq:responsive/breakpoints/phone@width=768

However, the AEM Grid CSS for the "phone" breakpoint reacts when the viewport is <=767px, which 768px is not, therefor the persisted values on the component's `cq:responsive/phone` node are being ignored.

Aligning the CSS's max-width and the breakpoints max-width both to 768px resolves this conflict.

We may want to fix-up this piece of WKND actually, as only define 2 breakpoints (phone, tablet) and an implicit 3rd (default, which is anything > tablet), however the emulator's WKND ships do not let you differentiate between tablet and desktop, making it somewhat awkward/confusing.

## Motivation and Context

See #277

## How Has This Been Tested?

Tested on AEM 6.5.7.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1451868/128406221-692ef37a-92ac-4d30-8fcc-ffce32d99496.png)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
