### PR TITLE
SKYOPS-17977 - Update WKND to latest AEM Analyser

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -117,9 +117,7 @@
                         <id>analyse-project</id>
                         <phase>verify</phase>
                         <goals>
-                            <goal>convert</goal>
-                            <goal>aggregate</goal>
-                            <goal>analyse</goal>
+                            <goal>project-analyse</goal>                           
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <componentGroupName>WKND Site</componentGroupName>
         <core.wcm.components.version>2.16.4</core.wcm.components.version>
         <uber.jar.version>6.4.4</uber.jar.version>
-        <aemanalyser.version>0.9.2</aemanalyser.version>
+        <aemanalyser.version>1.1.4</aemanalyser.version>
     </properties>
 
     <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <componentGroupName>WKND Site</componentGroupName>
         <core.wcm.components.version>2.16.4</core.wcm.components.version>
         <uber.jar.version>6.4.4</uber.jar.version>
-        <aemanalyser.version>1.1.4</aemanalyser.version>
+        <aemanalyser.version>1.1.8</aemanalyser.version>
     </properties>
 
     <organization>


### PR DESCRIPTION

## Description
Update WKND to latest AEM Analyser 1.1.4.

## Related Issue
The WKND codebase (https://github.com/adobe/aem-guides-wknd/blob/master/pom.xml) still uses the AEM Analyser version 0.9.2. The latest version is 1.1.4.

## Motivation and Context

Outdated Version of AEM Analyser
