### PR TITLE
#289 Remove custom canonical URL

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/page/customheaderlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/page/customheaderlibs.html
@@ -14,7 +14,6 @@
     limitations under the License.
 */-->
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<link rel="canonical" href="https://wknd.site${currentPage.path @ extension= 'html' }" />
 <sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"
      data-sly-call="${clientlib.css @ categories='wknd.base'}"/>
 


### PR DESCRIPTION
Remove the custom tag - as Core Components now have their own tag added. @godanny86 might have impact on the tutorial - as in part that has to be removed.