### PR TITLE
#288 add /content to match

### DIFF
--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -73,13 +73,14 @@ Include conf.d/variables/custom.vars
         Header set Age 0
     </LocationMatch>
     # HTML pages: CDN cache for 10min with background refresh to avoid MISS, also incl. html requests with query parameter
-    <LocationMatch "\.html$">
+    # Cache-Control headers will always be added so it is important to ensure that matching html pages under /content/ are intended to be public
+    <LocationMatch "^/content/.*\.html$">
         Header unset Cache-Control
         Header always set Cache-Control "max-age=120,s-maxage=600,stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
     </LocationMatch>
     # Content Services/Sling Model Exporter: CDN cache for 10min with background refresh to avoid MISS on CDN
-    <LocationMatch "\.model\.json$">
+    <LocationMatch "^/content/.*\.model\.json$">
         Header set Cache-Control "max-age=120,s-maxage=600,stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
     </LocationMatch>

--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -85,7 +85,7 @@ Include conf.d/variables/custom.vars
         Header set Age 0
     </LocationMatch>
     # Core Component Image Component: long-term caching (30 days) for immutable URLs, background refresh to avoid MISS
-    <LocationMatch "\.coreimg.*\.(?i:jpe?g|png|gif|svg)$">
+    <LocationMatch "^/content/.*\.coreimg.*\.(?i:jpe?g|png|gif|svg)$">
         Header set Cache-Control "max-age=2592000,stale-while-revalidate=43200,stale-if-error=43200,public,immutable" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
     </LocationMatch> 


### PR DESCRIPTION
First change - make LocationMatch less broad - and only focus on /content. The URL rewriter uses PT (Pass Thru) - with that the LocationMatch is done on the full JCR path.