### PR TITLE
Configure Sling Mappings and Sitemap Generation

### DIFF
--- a/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish.dev/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish.dev/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.cfg.json
@@ -1,5 +1,3 @@
 {
-  "resource.resolver.mapping": [
-    "/content/wknd/</", "/:/"
-  ]
+  "resource.resolver.map.location": "/etc/map.publish"
 }

--- a/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish.prod/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish.prod/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.cfg.json
@@ -1,5 +1,3 @@
 {
-  "resource.resolver.mapping": [
-    "/content/wknd/</", "/:/"
-  ]
+  "resource.resolver.map.location": "/etc/map.publish"
 }

--- a/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish.stage/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish.stage/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.cfg.json
@@ -1,5 +1,3 @@
 {
-  "resource.resolver.mapping": [
-    "/content/wknd/</", "/:/"
-  ]
+  "resource.resolver.map.location": "/etc/map.publish"
 }

--- a/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish/org.apache.sling.sitemap.impl.SitemapScheduler~default.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/wknd/osgiconfig/config.publish/org.apache.sling.sitemap.impl.SitemapScheduler~default.cfg.json
@@ -1,0 +1,4 @@
+{
+    "scheduler.name": "default",
+    "scheduler.expression": "0 0 0 * * ?"
+}

--- a/ui.content.sample/src/main/content/jcr_root/content/wknd/ca/en/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/content/wknd/ca/en/.content.xml
@@ -14,6 +14,7 @@
         jcr:primaryType="cq:PageContent"
         jcr:title="WKND Adventures and Travel"
         sling:resourceType="wknd/components/page"
+        sling:sitemapRoot="{Boolean}true"
         pageTitle="Home">
         <root
             cq:lastRolledout="{Date}2020-09-30T17:38:05.410-07:00"

--- a/ui.content.sample/src/main/content/jcr_root/content/wknd/us/en/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/content/wknd/us/en/.content.xml
@@ -14,6 +14,7 @@
         jcr:primaryType="cq:PageContent"
         jcr:title="WKND Adventures and Travel"
         sling:resourceType="wknd/components/page"
+        sling:sitemapRoot="{Boolean}true"
         pageTitle="Home">
         <root
             cq:lastRolledout="{Date}2020-09-30T17:38:06.417-07:00"

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -58,7 +58,7 @@
                         </jackrabbit-nodetypes>
                         <jackrabbit-filter>
                             <options>
-                                <validRoots>/conf,/content,/content/experience-fragments,/content/dam,/content/cq:tags</validRoots>
+                                <validRoots>/conf,/content,/content/experience-fragments,/content/dam,/content/cq:tags,/etc</validRoots>
                             </options>
                         </jackrabbit-filter>
                     </validatorsSettings>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/wknd-site-reverse/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/wknd-site-reverse/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"
+    jcr:mixinTypes="[sling:MappingSpec]"
+    sling:internalRedirect="/content/wknd/(.+)"
+    sling:match="$[env:AEM_DOMAIN_WKND_SITE]/$1"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/wknd-site/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/wknd-site/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"
+    jcr:mixinTypes="[sling:MappingSpec]"
+    sling:internalRedirect="[/,/content/wknd]"
+    sling:match="$[env:AEM_DOMAIN_WKND_SITE].\\d+"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR contributes the configuration of a Sling Mapping using a `AEM_DOMAIN_WKND_SITE` environment variable. It is activated only for the `publish.dev`, `publish.stage` and `publish.prod` runmode by the configuration of the Resource Resolver Factory pointing to the mappings directory `/etc/map.publish`. 

Additionally a SitemapGenerator configuration was added to run Sitemap generation once a day at midnight. Both homepages `us/en` and `ca/en` were marked as sitemap roots.

## Related Issue

#292 

## Motivation and Context

Achieve a 100% SEO score with WKND.

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
