### PR TITLE
#318 Change CDN cache strategy

### DIFF
--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -61,10 +61,10 @@ Include conf.d/variables/custom.vars
     ErrorDocument 503 ${500_PAGE}
     ErrorDocument 504 ${500_PAGE}
     
-    ## Default Fastly Cache Settings for AEM - V20211021
-    # Theme Sources via Clientlib: cache mutable resources for 24h on CDN and background refresh to avoid MISS
-    <LocationMatch "^/etc\.clientlibs/.*\.(?i:json|png|gif|jpe?g|svg)$">
-        Header set Cache-Control "max-age=7200,s-maxage=86400,stale-while-revalidate=43200,stale-if-error=43200,public" "expr=%{REQUEST_STATUS} < 400"
+    ## Default Fastly Cache Settings for AEM - V20220207
+    # Theme Sources via Clientlib: cache mutable resources for max 24h on CDN and background refresh after 12h to avoid MISS
+    <LocationMatch "^/etc\.clientlibs/.*\.(?i:json|png|gif|webp|jpe?g|svg)$">
+        Header set Cache-Control "max-age=43200,stale-while-revalidate=43200,stale-if-error=43200,public" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
     </LocationMatch>
     # Theme Sources via Clientlib: long-term caching (30 days) for immutable URLs, background refresh to avoid MISS
@@ -72,26 +72,34 @@ Include conf.d/variables/custom.vars
         Header set Cache-Control "max-age=2592000,stale-while-revalidate=43200,stale-if-error=43200,public,immutable" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
     </LocationMatch>
-    # HTML pages: CDN cache for 10min with background refresh to avoid MISS, also incl. html requests with query parameter
+    # HTML pages: Cache for 5min with background refresh 1h on browser and 12h on CDN to avoid MISS, also incl. requests with query parameter
     # Cache-Control headers will always be added so it is important to ensure that matching html pages under /content/ are intended to be public
     <LocationMatch "^/content/.*\.html$">
         Header unset Cache-Control
-        Header always set Cache-Control "max-age=120,s-maxage=600,stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
+        Header always set Cache-Control "max-age=300,stale-while-revalidate=3600" "expr=%{REQUEST_STATUS} < 400"
+        Header always set Surrogate-Control "stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
     </LocationMatch>
-    # Content Services/Sling Model Exporter: CDN cache for 10min with background refresh to avoid MISS on CDN
+    # Content Services/Sling Model Exporter: Cache for 5min with background refresh 1h on browser and 12h on CDN to avoid MISS
     <LocationMatch "^/content/.*\.model\.json$">
-        Header set Cache-Control "max-age=120,s-maxage=600,stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
+        Header set Cache-Control "max-age=300,stale-while-revalidate=3600" "expr=%{REQUEST_STATUS} < 400"
+        Header set Surrogate-Control "stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
+        Header set Age 0
+    </LocationMatch>
+    # Core Component Search Component: Cache for 5min with background refresh 1h on browser and 12h on CDN to avoid MISS, also incl. requests with query parameter
+    <LocationMatch "^/content/.*\.searchresults\.json.*">
+        Header always set Cache-Control "max-age=300,stale-while-revalidate=3600" "expr=%{REQUEST_STATUS} < 400"
+        Header always set Surrogate-Control "stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
     </LocationMatch>
     # Core Component Image Component: long-term caching (30 days) for immutable URLs, background refresh to avoid MISS
     <LocationMatch "^/content/.*\.coreimg.*\.(?i:jpe?g|png|gif|svg)$">
         Header set Cache-Control "max-age=2592000,stale-while-revalidate=43200,stale-if-error=43200,public,immutable" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
-    </LocationMatch> 
-    # Images/Video from DAM: cache mutable resources for 24h on CDN and background refresh to avoid MISS
-    <LocationMatch "^/content/dam/.*\.(?i:jpe?g|gif|js|mov|png|svg|txt|zip|ico)$">
-        Header set Cache-Control "max-age=7200,s-maxage=86400,stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
+    </LocationMatch>
+    # Images/Video from DAM: cache mutable resources for max 24h on CDN and background refresh after 12h to avoid MISS
+    <LocationMatch "^/content/dam/.*\.(?i:jpe?g|gif|js|mov|mp4|png|svg|txt|zip|ico|webp|pdf)$">
+        Header set Cache-Control "max-age=43200,stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
         Header set Age 0
     </LocationMatch>
 </VirtualHost>

--- a/dispatcher/src/conf.d/rewrites/rewrite.rules
+++ b/dispatcher/src/conf.d/rewrites/rewrite.rules
@@ -8,7 +8,7 @@
 Include conf.d/rewrites/default_rewrite.rules
 
 # make sure the root site redirects are cache on CDN to avoid origin round-trip
-Header always set Cache-Control "max-age=60,s-maxage=600,stale-while-revalidate=43200,stale-if-error=43200" env=cdncache
+Header always set Cache-Control "max-age=300,stale-while-revalidate=43200,stale-if-error=43200" env=cdncache
 
 # redirect traffic from www to http home page
 RewriteCond %{HTTP_HOST} www.wknd.site [NC]


### PR DESCRIPTION
1. change caching strategy to avoid age over-run that makes the browser repeatedly doing a last-modified-since
2. add rules to cache search results
3. add more mime-types in dam

These settings are in production on https://wknd.site/ and https://aemcomponents.dev/ 