### PR TITLE
Include ContextHub by default to enable site targeting scenarios

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/page/customheaderlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/page/customheaderlibs.html
@@ -15,9 +15,8 @@
 */-->
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<!--/* Include Context Hub 
+<!--/* Include Context Hub */-->
 <sly data-sly-resource="${'contexthub' @ resourceType='granite/contexthub/components/contexthub'}"/>
-*/-->
 
 <!--/* Manifest */-->
 <meta name="theme-color" content="#FFEA00">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Enable Contexthub by default so that targeting scenarios can be enabled. We need this to validate and write test cases for targeting repo. 

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

We are migrating from we-retail to wknd for CQ/integration-target repository and hence we need this change.

## How Has This Been Tested?

This is not a new feature. we are just enabling a feature by default. We are writing test cases in CQ/integration-target for targeting scenarios. This is also documented here: https://experienceleague.adobe.com/docs/experience-manager-learn/sites/personalization/context-hub-technical-video-setup.html?lang=en

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
