### PR TITLE
Make sure custom clientlibs are loaded asynchronously

### DIFF
--- a/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/policies/.content.xml
+++ b/ui.content.sample/src/main/content/jcr_root/conf/wknd/settings/wcm/policies/.content.xml
@@ -1062,7 +1062,8 @@
                     jcr:title="WKND Site Theme"
                     sling:resourceType="wcm/core/components/policy/policy"
                     clientlibs="[wknd.site,wknd.base]"
-                    clientlibsJsHead="wknd.dependencies">
+                    clientlibsJsHead="wknd.dependencies"
+                    clientlibsAsync="true">
                     <jcr:content
                         cq:lastReplicated="{Date}2019-10-22T13:34:50.533-07:00"
                         cq:lastReplicatedBy="admin"
@@ -1078,7 +1079,8 @@
                     jcr:primaryType="nt:unstructured"
                     jcr:title="Experience Fragment Web"
                     sling:resourceType="wcm/core/components/policy/policy"
-                    clientlibs="[wknd.site,wknd.base]">
+                    clientlibs="[wknd.site,wknd.base]"
+                    clientlibsAsync="true">
                     <jcr:content jcr:primaryType="nt:unstructured"/>
                 </policy_1572461714642>
             </xfpage>


### PR DESCRIPTION
- add async loading to the WKND page policies

Fixes #333 

Note: although Core Components 2.19 is not yet released, this PR can still be merged and won't interfere with the current setup as the new property `clientlibsAsync` will be ignored until 2.19 is used.