### PR TITLE
Update to Core Components 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <bnd.version>5.1.2</bnd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <aem.sdk.api>2022.4.7138.20220427T075748Z</aem.sdk.api>
+        <aem.sdk.api>2022.4.7138.20220427T075748Z-220400</aem.sdk.api>
         <componentGroupName>WKND Site</componentGroupName>
         <core.wcm.components.version>2.19.0</core.wcm.components.version>
         <uber.jar.version>6.5.10</uber.jar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <bnd.version>5.1.2</bnd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <aem.sdk.api>2021.5.5343.20210524T070738Z-210527</aem.sdk.api>
+        <aem.sdk.api>2022.4.7138.20220427T075748Z</aem.sdk.api>
         <componentGroupName>WKND Site</componentGroupName>
         <core.wcm.components.version>2.19.0</core.wcm.components.version>
         <uber.jar.version>6.5.10</uber.jar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <aem.sdk.api>2021.5.5343.20210524T070738Z-210527</aem.sdk.api>
         <componentGroupName>WKND Site</componentGroupName>
-        <core.wcm.components.version>2.18.6</core.wcm.components.version>
+        <core.wcm.components.version>2.19.0</core.wcm.components.version>
         <uber.jar.version>6.5.10</uber.jar.version>
         <aemanalyser.version>1.3.0</aemanalyser.version>
     </properties>


### PR DESCRIPTION
## Description

Update to Core Components 2.19.0.

Warning: the build is failing because the AEMaaCS image used to build the project does not export the 2.19 Core Component packages. This PR should only be merged once the AEMaaCS image contains CC 2.19.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
