### PR TITLE
Update dispatcher immutable files and enforcer plugin to unify md5 checksums

### DIFF
--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -38,202 +38,90 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <!-- enforce that immutable files are not touched: https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure -->
+                    <execution>
+                        <id>enforce-checksum-of-immutable-files</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- rules being inserted by archetype-pre-package.groovy -->
+                                <requireFileChecksum>
+                                    <file>src/conf.d/available_vhosts/default.vhost</file>
+                                    <checksum>d4bc425c3f0ce825450019ce2501e14e</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/available_vhosts/default.vhost</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.d/dispatcher_vhost.conf</file>
+                                    <checksum>81cce48a27703d0cdc3c1d7d61efc10b</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/dispatcher_vhost.conf</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.d/rewrites/default_rewrite.rules</file>
+                                    <checksum>92800e1502954d8038b103f027cee332</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/rewrites/default_rewrite.rules</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.dispatcher.d/available_farms/default.farm</file>
+                                    <checksum>0a5ad761467bc7a57c53e647b9d7b671</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/available_farms/default.farm</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.dispatcher.d/cache/default_invalidate.any</file>
+                                    <checksum>1335157699f9ea9b51f72ab868c7e885</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/cache/default_invalidate.any</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.dispatcher.d/cache/default_rules.any</file>
+                                    <checksum>daf2c7e3b81a862f5ee4f27b4c22de2f</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/cache/default_rules.any</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.dispatcher.d/clientheaders/default_clientheaders.any</file>
+                                    <checksum>b9b4548f5570cffe7a7f10ffb219e27e</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/clientheaders/default_clientheaders.any</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.dispatcher.d/dispatcher.any</file>
+                                    <checksum>f452e3f790c96de440dca7d2ae3630a6</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/dispatcher.any</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.dispatcher.d/filters/default_filters.any</file>
+                                    <checksum>93d6896c1b92829af8707ead21b7e62a</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/filters/default_filters.any</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.dispatcher.d/renders/default_renders.any</file>
+                                    <checksum>3c7472f635d35795ec270e7b0b40a07a</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/renders/default_renders.any</message>
+                                </requireFileChecksum>
+                                <requireFileChecksum>
+                                    <file>src/conf.dispatcher.d/virtualhosts/default_virtualhosts.any</file>
+                                    <checksum>dd1caafd65a7f5e249fbcdaa0e88ed9e</checksum>
+                                    <type>md5</type>
+                                    <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/virtualhosts/default_virtualhosts.any</message>
+                                </requireFileChecksum>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>notOnWindows</id>
-            <activation>
-                <os>
-                    <family>!windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <!-- enforce that immutable files are not touched: https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure -->
-                            <execution>
-                                <id>enforce-checksum-of-immutable-files</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <!-- rules being inserted by archetype-pre-package.groovy -->
-                                        <requireFileChecksum>
-                                            <file>src/conf.d/available_vhosts/default.vhost</file>
-                                            <checksum>d4bc425c3f0ce825450019ce2501e14e</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/available_vhosts/default.vhost</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.d/dispatcher_vhost.conf</file>
-                                            <checksum>5c4b79b90d98207bd4866de6ef61679b</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/dispatcher_vhost.conf</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.d/rewrites/default_rewrite.rules</file>
-                                            <checksum>92800e1502954d8038b103f027cee332</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/rewrites/default_rewrite.rules</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/available_farms/default.farm</file>
-                                            <checksum>0a5ad761467bc7a57c53e647b9d7b671</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/available_farms/default.farm</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/cache/default_invalidate.any</file>
-                                            <checksum>1335157699f9ea9b51f72ab868c7e885</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/cache/default_invalidate.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/cache/default_rules.any</file>
-                                            <checksum>daf2c7e3b81a862f5ee4f27b4c22de2f</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/cache/default_rules.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/clientheaders/default_clientheaders.any</file>
-                                            <checksum>b9b4548f5570cffe7a7f10ffb219e27e</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/clientheaders/default_clientheaders.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/dispatcher.any</file>
-                                            <checksum>f452e3f790c96de440dca7d2ae3630a6</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/dispatcher.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/filters/default_filters.any</file>
-                                            <checksum>9ec99c914a961bbbab406218f8c1fb51</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/filters/default_filters.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/renders/default_renders.any</file>
-                                            <checksum>3c7472f635d35795ec270e7b0b40a07a</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/renders/default_renders.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/virtualhosts/default_virtualhosts.any</file>
-                                            <checksum>dd1caafd65a7f5e249fbcdaa0e88ed9e</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/virtualhosts/default_virtualhosts.any</message>
-                                        </requireFileChecksum>
-
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>onWindows</id>
-            <activation>
-                <os>
-                    <family>windows</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <!-- enforce that immutable files are not touched: https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure -->
-                            <execution>
-                                <id>enforce-checksum-of-immutable-files</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <!-- rules being inserted by archetype-pre-package.groovy -->
-                                        <requireFileChecksum>
-                                            <file>src/conf.d/available_vhosts/default.vhost</file>
-                                            <checksum>3601d8516d22447eea5ad5ff35be7fc5</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/available_vhosts/default.vhost</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.d/dispatcher_vhost.conf</file>
-                                            <checksum>b37f0821edbb80c57080872a4478d682</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/dispatcher_vhost.conf</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.d/rewrites/default_rewrite.rules</file>
-                                            <checksum>359c9779632fd82aaed3643dd952e647</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/rewrites/default_rewrite.rules</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/available_farms/default.farm</file>
-                                            <checksum>f0f389356a7c6c124f712b48d3a277ca</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/available_farms/default.farm</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/cache/default_invalidate.any</file>
-                                            <checksum>b70b37e34985ad67b07f8b41652c0d57</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/cache/default_invalidate.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/cache/default_rules.any</file>
-                                            <checksum>335fc064f345107ff46975b55cd1cf9c</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/cache/default_rules.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/clientheaders/default_clientheaders.any</file>
-                                            <checksum>acfa31c74c1a34d8e30658a09358f8d7</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/clientheaders/default_clientheaders.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/dispatcher.any</file>
-                                            <checksum>c66f76e1138b98527d9904f23202b3b0</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/dispatcher.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/filters/default_filters.any</file>
-                                            <checksum>70e31f0d18a9656075f928ee108aa366</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/filters/default_filters.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/renders/default_renders.any</file>
-                                            <checksum>3e86b6fc52209d66692667eae51caaa6</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/renders/default_renders.any</message>
-                                        </requireFileChecksum>
-                                        <requireFileChecksum>
-                                            <file>src/conf.dispatcher.d/virtualhosts/default_virtualhosts.any</file>
-                                            <checksum>39d92a0a0b11a1a69fe33a791626c7d0</checksum>
-                                            <type>md5</type>
-                                            <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/virtualhosts/default_virtualhosts.any</message>
-                                        </requireFileChecksum>
-
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/dispatcher/src/conf.d/dispatcher_vhost.conf
+++ b/dispatcher/src/conf.d/dispatcher_vhost.conf
@@ -10,6 +10,36 @@ ServerName dispatcher
 Include conf.d/variables/default.vars
 Include conf.d/variables/global.vars
 
+
+# WARNING!!! The probe paths below are INTERNAL and RESERVED - please DO NOT USE them in your virtual host configurations!
+
+# Liveness probe URL
+Alias "/system/probes/live" /etc/httpd/probes/live-status.json
+# Readiness probe URL
+Alias "/system/probes/ready" /etc/httpd/probes/ready-status.json
+# Startup probe URL
+Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
+
+# internal probes endpoint
+<LocationMatch "/system/probes">
+    RewriteEngine Off
+</LocationMatch>
+
+<Directory "/etc/httpd/probes">
+    SetHandler default-handler
+    AllowOverride None
+    Require all granted
+</Directory>
+
+
+#SKYOPS-13837: Proxy static frontend code requests through dispatcher
+<IfDefine FRONTEND_SUPPORT>
+    SSLProxyEngine on
+    <LocationMatch "/libs/cq/frontend-static">
+        RewriteRule "^/mnt/var/www/html/libs/cq/frontend-static(/[^\.].*)$" "%{env:FRONTEND_URI_PREFIX}$1?%{env:FRONTEND_URI_SUFFIX}" [P,L]
+    </LocationMatch>
+</IfDefine>
+
 # CQ-4315090: Allow the functional replication to access publish instance directly for dev and stage environments
 <IfDefine ENVIRONMENT_DEV>
     <LocationMatch "/content/test-site/">
@@ -68,8 +98,14 @@ Include conf.d/variables/global.vars
 	Header unset Age
 </IfDefine>
 
-# Allow ingressroute checks through on /systemready (regardless of dispatcher filters)
+# (legacy) Allow ingressroute checks through on /systemready (regardless of dispatcher filters)
 <Location "/systemready">
+	ProxyPass http://${AEM_HOST}:${AEM_PORT}/systemready
+	RewriteEngine Off
+</Location>
+
+# new Health probe URL to legacy /systemready URL mapping
+<Location "/system/probes/health">
 	ProxyPass http://${AEM_HOST}:${AEM_PORT}/systemready
 	RewriteEngine Off
 </Location>
@@ -85,12 +121,36 @@ Include conf.d/variables/global.vars
 # CQ-4287185: Allow access to magento reverse-proxy endpoint
 <IfDefine COMMERCE>
 	SSLProxyEngine on
+	# CIF-2557 add ProxyRemote to tunnel reverse-proxy traffic through egress proxy if available
+	<IfDefine HTTP_EGRESS_PROXY>
+		ProxyRemote ${COMMERCE_ENDPOINT} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
+	</IfDefine>
 	<LocationMatch "/api/graphql">
 		ProxyPass        ${COMMERCE_ENDPOINT}
 		ProxyPassReverse ${COMMERCE_ENDPOINT}
 		RewriteEngine Off
 	</LocationMatch>
 </IfDefine>
+
+# Disable access to default CGI scripts
+<Directory "/var/www/localhost/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all denied
+</Directory>
+
+# internal metadata endpoint
+Alias "/gitinit-status" /etc/httpd/metadata/gitinit-status.json
+
+<LocationMatch "/gitinit-status">
+    RewriteEngine Off
+</LocationMatch>
+
+<Directory "/etc/httpd/metadata">
+	SetHandler default-handler
+    AllowOverride None
+    Require expr "%{HTTP_HOST} == '${POD_NAME}'"
+</Directory>
 
 Include conf.d/enabled_vhosts/*.vhost
 

--- a/dispatcher/src/conf.dispatcher.d/filters/default_filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/default_filters.any
@@ -52,7 +52,7 @@
 
 # AEM Forms specific filters
 # to allow AF specific endpoints for prefill, submit and sign
-/0032 { /type "allow" /path "/content/forms/af/*" /method "POST" /selectors '(submit|internalsubmit|agreement|signSubmit|prefilldata|save)' /extension '(jsp|json)' }
+/0032 { /type "allow" /path "/content/forms/af/*" /method "POST" /selectors '(submit|internalsubmit|agreement|signSubmit|prefilldata|save|analyticsconfigparser)' /extension '(jsp|json)' }
 
 # to allow AF specific endpoints for thank you page
 /0033 { /type "allow" /path "/content/forms/af/*"  /method "GET" /selectors '(guideThankYouPage|guideAsyncThankYouPage)'  /extension '(html)'}
@@ -69,6 +69,9 @@
 # to allow invoke service functionality (FDM)
 /0037 { /type "allow" /path "/content/forms/*" /selectors '(af)'  /extension '(dermis)' }
 
+# to allow forms portal draft and submissions component operation servlet
+/0038 { /type "allow" /path "/content/*" /method "GET" /selectors '(fp)' /extension '(operation)' }
+
 # AEM Screens Filters
 # to allow AEM Screens channels selectors
 /0050 { /type "allow" /method "GET" /url "/screens/channels.json" }
@@ -80,6 +83,12 @@
 # to allow site30 theme servlet
 /0052 { /type "allow" /extension "theme" /path "/content/*" }
 
+# Allow manifest.webmanifest files located in the content
+/0053 { /type "allow" /extension "webmanifest" /path "/content/*/manifest" }
+
+# Allow Apache Sling Sitemap selectors: sitemap, sitemap-index, sitemap.any-nested-or-named-sitemap
+/0054 { /type "allow" /method "GET" /path "/content/*" /selectors 'sitemap(-index)?' /extension "xml" }
+
 # Allow GraphQL & preflight requests
 # GraphQL also supports "GET" requests, if you intend to use "GET" add a rule in filters.any
 /0060 { /type "allow" /method '(POST|OPTIONS)' /url "/content/_cq_graphql/*/endpoint.json" }
@@ -87,5 +96,5 @@
 # GraphQL Persisted Queries & preflight requests
 /0061 { /type "allow" /method '(GET|POST|OPTIONS)' /url "/graphql/execute.json*" }
 
-# Allow Forms Doc Generation requests
-/0062 { /type "allow" /method "POST" /url "/adobe/forms/doc/*" }
+# Allow Forms Document Services requests
+/0062 { /type "allow" /method "POST" /url "/adobe/forms/*" }

--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@ Bundle-DocURL:
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <!-- Maven Dependency Plugin -->
                 <plugin>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the immutable files to dispatcher sdk version 2.0.91.
Also updates the enforcer plugin version so that there is no need for separate linux and windows checksums.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
