### PR TITLE
Fix for parallel process not working on windows.

### DIFF
--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -14,7 +14,9 @@
     "prod": "webpack --config ./webpack.prod.js && clientlib --verbose",
     "start": "webpack-dev-server --open --config ./webpack.dev.js",
     "sync": "aemsync -d -p ../ui.apps/src/main/content",
-    "watch": "webpack-dev-server --config ./webpack.dev.js --env writeToDisk & chokidar -c \"clientlib\" ./dist & aemsync -w ../ui.apps/src/main/content",
+    "chokidar": "chokidar -c \"clientlib\" ./dist",
+    "aemsyncro": "aemsync -w ../ui.apps/src/main/content",
+    "watch": "npm-run-all --parallel web chokidar aemsyncro",
     "storybook": "start-storybook -p 6006"
   },
   "devDependencies": {
@@ -42,6 +44,7 @@
     "glob-import-loader": "^1.2.0",
     "html-webpack-plugin": "^5.5.0",
     "mini-css-extract-plugin": "^2.4.5",
+    "npm-run-all": "^4.1.5",
     "postcss": "^8.2.15",
     "postcss-loader": "^6.2.1",
     "sass": "^1.45.0",


### PR DESCRIPTION
Parallel using ampersand is not supported on windows.
npm-run-all enables windows to run watch properly.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Parallel processing using ampersands is not supported on Windows platform.
Therefore `npm run watch`  fails to run properly on windows.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Following the WKND tutorial and running across this problem has hindered mine and my colleagues progress.
We came up with this solution.

## How Has This Been Tested?

We tested it on Windows and Linux and it seems to perform as expected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
