### PR TITLE
Feature/use uicontent wknd shared 2.0.0

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -86,7 +86,7 @@
                         </embedded>
                         <embedded>
                             <groupId>com.adobe.aem.guides</groupId>
-                            <artifactId>aem-guides-wknd-shared.all</artifactId>
+                            <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
                             <type>zip</type>
                             <target>/apps/wknd-vendor-packages/content/install</target>
                         </embedded>
@@ -250,10 +250,10 @@
                                 </embedded>
                                 <embedded>
                                     <groupId>com.adobe.aem.guides</groupId>
-                                    <artifactId>aem-guides-wknd-shared.all</artifactId>
+                                    <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
                                     <type>zip</type>
                                     <target>/apps/wknd-vendor-packages/content/install</target>
-                                </embedded>                                
+                                </embedded>                           
                             </embeddeds>
                         </configuration>
                     </plugin>
@@ -308,7 +308,7 @@
         <!-- WKND Shared -->
         <dependency>
             <groupId>com.adobe.aem.guides</groupId>
-            <artifactId>aem-guides-wknd-shared.all</artifactId>
+            <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
             <type>zip</type>
         </dependency>        
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -741,7 +741,7 @@ Bundle-DocURL:
             <!-- WKND Shared -->
             <dependency>
                 <groupId>com.adobe.aem.guides</groupId>
-                <artifactId>aem-guides-wknd-shared.all</artifactId>
+                <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
                 <version>${wknd-shared.version}</version>
                 <type>zip</type>
             </dependency>

--- a/ui.content.sample/pom.xml
+++ b/ui.content.sample/pom.xml
@@ -70,7 +70,7 @@
                         </dependency>
                         <dependency>
                             <groupId>com.adobe.aem.guides</groupId>
-                            <artifactId>aem-guides-wknd-shared.all</artifactId>
+                            <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
                             <version>${wknd-shared.version}</version>
                         </dependency>
                     </dependencies>
@@ -111,7 +111,7 @@
         </dependency>
         <dependency>
             <groupId>com.adobe.aem.guides</groupId>
-            <artifactId>aem-guides-wknd-shared.all</artifactId>
+            <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
             <version>${wknd-shared.version}</version>
             <type>zip</type>
         </dependency>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -70,7 +70,7 @@
                         </dependency>
                         <dependency>
                             <groupId>com.adobe.aem.guides</groupId>
-                            <artifactId>aem-guides-wknd-shared.all</artifactId>
+                            <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
                         </dependency>
                     </dependencies>
                 </configuration>
@@ -104,7 +104,7 @@
         </dependency>
         <dependency>
             <groupId>com.adobe.aem.guides</groupId>
-            <artifactId>aem-guides-wknd-shared.all</artifactId>
+            <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
             <version>${wknd-shared.version}</version>
             <type>zip</type>
         </dependency>

--- a/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -4,5 +4,4 @@
     <filter root="/content/wknd" mode="merge"/>
     <filter root="/content/dam/wknd" mode="merge"/>
     <filter root="/content/experience-fragments/wknd" mode="merge"/>
-    <filter root="/content/cq:graphql" mode="merge" />
 </workspaceFilter>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- use the `aem-guides-wknd-shared.ui.content` module instead of all
- Ensures that proper dependency chain is used (i.e tags from wknd-shared are install **before** wknd content)
