### PR TITLE
revert junit throws

### DIFF
--- a/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
+++ b/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
@@ -48,170 +48,170 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public class GraphQlIT {
 
-	private static final String TEST_AUTHOR_FIRST_NAME = "Ian";
-  
+    private static final String TEST_AUTHOR_FIRST_NAME = "Ian";
+
     private static final String TEST_AUTHOR_LAST_NAME = "Provo";
-  
+
     private static final String WKND_SHARED_GRAPHQL_ENDPOINT = "/content/_cq_graphql/wknd-shared/endpoint.json";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphQlIT.class);
 
     @Rule
-	public ExpectedException thrown = ExpectedException.none();
+    public ExpectedException thrown = ExpectedException.none();
 
-	@ClassRule
-	public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
+    @ClassRule
+    public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
 
-	static AEMHeadlessClient headlessClientAuthor;
+    static AEMHeadlessClient headlessClientAuthor;
 
-	@BeforeClass
-	public static void beforeClass() {
-		try {
+    @BeforeClass
+    public static void beforeClass() {
+        try {
             headlessClientAuthor = getHeadlessClient(cqBaseClassRule.authorRule.getConfiguration());
         } catch (URISyntaxException e) {
             LOGGER.error("Error attempting to initialize headless client", e);
         }
-	}
+    }
 
-	private static AEMHeadlessClient getHeadlessClient(InstanceConfiguration instanceConfig) throws URISyntaxException {
+    private static AEMHeadlessClient getHeadlessClient(InstanceConfiguration instanceConfig) throws URISyntaxException {
         final String graphQLEndpoint = instanceConfig.getUrl() + WKND_SHARED_GRAPHQL_ENDPOINT;
-		return AEMHeadlessClient.builder() //
-				.endpoint(graphQLEndpoint) //
-				.basicAuth(instanceConfig.getAdminUser(), instanceConfig.getAdminPassword()).build();
-	}
+        return AEMHeadlessClient.builder() //
+                .endpoint(graphQLEndpoint) //
+                .basicAuth(instanceConfig.getAdminUser(), instanceConfig.getAdminPassword()).build();
+    }
 
-	@Test
-	public void testQuery() {
+    @Test
+    public void testQuery() {
 
-		String query = "{\n" + //
-				"  articleList{\n" + //
-				"    items{ \n" + //
-				"      _path\n" + //
-				"      authorFragment{\n" + //
+        String query = "{\n" + //
+                "  articleList{\n" + //
+                "    items{ \n" + //
+                "      _path\n" + //
+                "      authorFragment{\n" + //
                 "        firstName\n" + //
                 "        lastName\n" + //
                 "         }\n" + //
-				"    } \n" + //
-				"  }\n" + //
-				"}";
-		GraphQlResponse response = headlessClientAuthor.runQuery(query);
-		assertNull(response.getErrors());
-		JsonNode responseData = response.getData();
+                "    } \n" + //
+                "  }\n" + //
+                "}";
+        GraphQlResponse response = headlessClientAuthor.runQuery(query);
+        assertNull(response.getErrors());
+        JsonNode responseData = response.getData();
 
-		assertNotNull(responseData);
-		JsonNode articleList = responseData.get("articleList");
-		assertNotNull(articleList);
-		JsonNode articleListItems = articleList.get("items");
-		assertNotNull(articleListItems);
-		assertEquals(7, articleListItems.size());
-		assertNotNull(articleListItems.get(0).get("_path"));
-		assertNotNull(articleListItems.get(0).get("authorFragment"));
-	}
+        assertNotNull(responseData);
+        JsonNode articleList = responseData.get("articleList");
+        assertNotNull(articleList);
+        JsonNode articleListItems = articleList.get("items");
+        assertNotNull(articleListItems);
+        assertEquals(7, articleListItems.size());
+        assertNotNull(articleListItems.get(0).get("_path"));
+        assertNotNull(articleListItems.get(0).get("authorFragment"));
+    }
 
-	@Test
-	public void testQueryWithSyntaxError() {
+    @Test
+    public void testQueryWithSyntaxError() {
 
         thrown.expect(AEMHeadlessClientException.class);
-		thrown.expectMessage("Invalid Syntax : offending token");
+        thrown.expectMessage("Invalid Syntax : offending token");
 
         String query = "{\n" + //
-				"  articleList{\n" + //
-				"    items{ \n" + //
-				"      _path\n" + //
-				"      author\n";
+                "  articleList{\n" + //
+                "    items{ \n" + //
+                "      _path\n" + //
+                "      author\n";
 
         headlessClientAuthor.runQuery(query);
-	}
+    }
 
-	@Test
-	public void testQueryWithErrorResponse() {
+    @Test
+    public void testQueryWithErrorResponse() {
 
         thrown.expect(AEMHeadlessClientException.class);
-		thrown.expectMessage("Field 'nonExisting' in type 'QueryType' is undefined");
+        thrown.expectMessage("Field 'nonExisting' in type 'QueryType' is undefined");
 
-		String query = "{ nonExisting { items{  _path } } }";
-		headlessClientAuthor.runQuery(query);
+        String query = "{ nonExisting { items{  _path } } }";
+        headlessClientAuthor.runQuery(query);
 
-	}
+    }
 
-	@Test
-	public void testQueryWithParameters() {
+    @Test
+    public void testQueryWithParameters() {
 
-		String query = "query($authorFirstName: String, $authorLastName: String) {\n" +
-            "articleList(filter: {\n" + 
-              "authorFragment: {\n" +
+        String query = "query($authorFirstName: String, $authorLastName: String) {\n" +
+                "articleList(filter: {\n" +
+                "authorFragment: {\n" +
                 "firstName: {\n" +
-                  "_expressions: {\n" +
-                    "value: $authorFirstName\n" +
-                  "}\n" +
+                "_expressions: {\n" +
+                "value: $authorFirstName\n" +
+                "}\n" +
                 "}\n" +
                 "lastName: {\n" +
-                  "_expressions: {\n" +
-                    "value: $authorLastName\n" +
-                  "}\n" +
+                "_expressions: {\n" +
+                "value: $authorLastName\n" +
                 "}\n" +
-              "}\n" +
-            "}) {\n" +
-              "items {\n" +
+                "}\n" +
+                "}\n" +
+                "}) {\n" +
+                "items {\n" +
                 "_path\n" +
                 "authorFragment {\n" +
-                  "firstName\n" +
-                  "lastName\n" +
+                "firstName\n" +
+                "lastName\n" +
                 "}\n" +
-              "}\n" +
-            "}\n" +
-          "}";          
+                "}\n" +
+                "}\n" +
+                "}";
 
-		Map<String, Object> vars = new HashMap<>();
-		vars.put("authorFirstName", TEST_AUTHOR_FIRST_NAME);
+        Map<String, Object> vars = new HashMap<>();
+        vars.put("authorFirstName", TEST_AUTHOR_FIRST_NAME);
         vars.put("authorLastName", TEST_AUTHOR_LAST_NAME);
 
-		GraphQlResponse response = headlessClientAuthor.runQuery(query, vars);
-		assertNull(response.getErrors());
-		JsonNode responseData = response.getData();
+        GraphQlResponse response = headlessClientAuthor.runQuery(query, vars);
+        assertNull(response.getErrors());
+        JsonNode responseData = response.getData();
 
-		assertNotNull(responseData);
-		JsonNode articleList = responseData.get("articleList");
-		assertNotNull(articleList);
-		JsonNode articleListItems = articleList.get("items");
-		assertNotNull(articleListItems);
-		assertEquals(1, articleListItems.size());
-		assertEquals(TEST_AUTHOR_FIRST_NAME, articleListItems.get(0).get("authorFragment").get("firstName").asText());
+        assertNotNull(responseData);
+        JsonNode articleList = responseData.get("articleList");
+        assertNotNull(articleList);
+        JsonNode articleListItems = articleList.get("items");
+        assertNotNull(articleListItems);
+        assertEquals(1, articleListItems.size());
+        assertEquals(TEST_AUTHOR_FIRST_NAME, articleListItems.get(0).get("authorFragment").get("firstName").asText());
         assertEquals(TEST_AUTHOR_LAST_NAME, articleListItems.get(0).get("authorFragment").get("lastName").asText());
-	}
+    }
 
-	@Test
-	public void testPersistedQuery() {
+    @Test
+    public void testPersistedQuery() {
 
-		GraphQlResponse response = headlessClientAuthor.runPersistedQuery("/wknd-shared/adventures-all");
-		assertNull(response.getErrors());
-		JsonNode responseData = response.getData();
+        GraphQlResponse response = headlessClientAuthor.runPersistedQuery("/wknd-shared/adventures-all");
+        assertNull(response.getErrors());
+        JsonNode responseData = response.getData();
 
-		assertNotNull(responseData);
-		JsonNode adventureListList = responseData.get("adventureList");
-		assertNotNull(adventureListList);
-		JsonNode adventureListItems = adventureListList.get("items");
-		assertNotNull(adventureListItems);
-		assertEquals(16, adventureListItems.size());
-		JsonNode firstAdvantureItem = adventureListItems.get(0);
-		assertNotNull(firstAdvantureItem.get("_path"));
-		assertNotNull(firstAdvantureItem.get("title"));
-		assertNotNull(firstAdvantureItem.get("price"));
-		assertNotNull(firstAdvantureItem.get("tripLength"));
-		assertNotNull(firstAdvantureItem.get("primaryImage"));
+        assertNotNull(responseData);
+        JsonNode adventureListList = responseData.get("adventureList");
+        assertNotNull(adventureListList);
+        JsonNode adventureListItems = adventureListList.get("items");
+        assertNotNull(adventureListItems);
+        assertEquals(16, adventureListItems.size());
+        JsonNode firstAdvantureItem = adventureListItems.get(0);
+        assertNotNull(firstAdvantureItem.get("_path"));
+        assertNotNull(firstAdvantureItem.get("title"));
+        assertNotNull(firstAdvantureItem.get("price"));
+        assertNotNull(firstAdvantureItem.get("tripLength"));
+        assertNotNull(firstAdvantureItem.get("primaryImage"));
 
-	}
+    }
 
-	@Test
-	public void testListPersistedQueries() {
+    @Test
+    public void testListPersistedQueries() {
 
-		List<PersistedQuery> listPersistedQueries = headlessClientAuthor.listPersistedQueries("wknd-shared");
+        List<PersistedQuery> listPersistedQueries = headlessClientAuthor.listPersistedQueries("wknd-shared");
 
-		assertFalse(listPersistedQueries.isEmpty());
-		PersistedQuery adventuresQuery = listPersistedQueries.stream()
-				.filter(p -> p.getShortPath().equals("/wknd-shared/adventures-all")).findFirst().get();
-		assertEquals("/wknd-shared/settings/graphql/persistentQueries/adventures-all", adventuresQuery.getLongPath());
-		assertThat(adventuresQuery.getQuery(), containsString("adventureList {"));
-	}
+        assertFalse(listPersistedQueries.isEmpty());
+        PersistedQuery adventuresQuery = listPersistedQueries.stream()
+                .filter(p -> p.getShortPath().equals("/wknd-shared/adventures-all")).findFirst().get();
+        assertEquals("/wknd-shared/settings/graphql/persistentQueries/adventures-all", adventuresQuery.getLongPath());
+        assertThat(adventuresQuery.getQuery(), containsString("adventureList {"));
+    }
 
 }

--- a/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
+++ b/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -32,7 +30,9 @@ import java.util.Map;
 import org.apache.sling.testing.clients.instance.InstanceConfiguration;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,11 +50,14 @@ public class GraphQlIT {
 
 	private static final String TEST_AUTHOR_FIRST_NAME = "Ian";
   
-  private static final String TEST_AUTHOR_LAST_NAME = "Provo";
+    private static final String TEST_AUTHOR_LAST_NAME = "Provo";
   
-  private static final String WKND_SHARED_GRAPHQL_ENDPOINT = "/content/_cq_graphql/wknd-shared/endpoint.json";
+    private static final String WKND_SHARED_GRAPHQL_ENDPOINT = "/content/_cq_graphql/wknd-shared/endpoint.json";
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(GraphQlIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GraphQlIT.class);
+
+    @Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	@ClassRule
 	public static final CQAuthorPublishClassRule cqBaseClassRule = new CQAuthorPublishClassRule();
@@ -107,25 +110,27 @@ public class GraphQlIT {
 
 	@Test
 	public void testQueryWithSyntaxError() {
+
+        thrown.expect(AEMHeadlessClientException.class);
+		thrown.expectMessage("Invalid Syntax : offending token");
+
         String query = "{\n" + //
 				"  articleList{\n" + //
 				"    items{ \n" + //
 				"      _path\n" + //
 				"      author\n";
 
-        AEMHeadlessClientException exception = assertThrows(AEMHeadlessClientException.class, 
-            () -> headlessClientAuthor.runQuery(query));
-        assertTrue(exception.getMessage().contains("Invalid Syntax : offending token"));
+        headlessClientAuthor.runQuery(query);
 	}
 
 	@Test
 	public void testQueryWithErrorResponse() {
 
-        String query = "{ nonExisting { items{  _path } } }";
-        AEMHeadlessClientException exception = assertThrows(AEMHeadlessClientException.class,
-            () -> headlessClientAuthor.runQuery(query));
-        
-        assertTrue(exception.getMessage().contains("Field 'nonExisting' in type 'QueryType' is undefined"));
+        thrown.expect(AEMHeadlessClientException.class);
+		thrown.expectMessage("Field 'nonExisting' in type 'QueryType' is undefined");
+
+		String query = "{ nonExisting { items{  _path } } }";
+		headlessClientAuthor.runQuery(query);
 
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reverts the use of `org.junit.Assert.assertThrows`

to fix `java.lang.NoSuchMethodError: org.junit.Assert.assertThrows` in CM pipeline

## Related Issue

Issue #360

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
