### PR TITLE
SITES-3659 - [Odin] Review Dispatcher config for Odin and contribute generic parts - Persisted queries

### DIFF
--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -53,13 +53,13 @@
                                 <!-- rules being inserted by archetype-pre-package.groovy -->
                                 <requireFileChecksum>
                                     <file>src/conf.d/available_vhosts/default.vhost</file>
-                                    <checksum>bd290b8da0d9f8bb25ec030b5e2b8897</checksum>
+                                    <checksum>d54181c3025ee07b08bb94429a5ca723</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/available_vhosts/default.vhost</message>
                                 </requireFileChecksum>
                                 <requireFileChecksum>
                                     <file>src/conf.d/dispatcher_vhost.conf</file>
-                                    <checksum>b30900e92c6995dfa6c68efcf159f4f0</checksum>
+                                    <checksum>b27855383754854932170e282fbf643a</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/dispatcher_vhost.conf</message>
                                 </requireFileChecksum>

--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -53,7 +53,7 @@
                                 <!-- rules being inserted by archetype-pre-package.groovy -->
                                 <requireFileChecksum>
                                     <file>src/conf.d/available_vhosts/default.vhost</file>
-                                    <checksum>d4bc425c3f0ce825450019ce2501e14e</checksum>
+                                    <checksum>bd290b8da0d9f8bb25ec030b5e2b8897</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/available_vhosts/default.vhost</message>
                                 </requireFileChecksum>
@@ -65,7 +65,7 @@
                                 </requireFileChecksum>
                                 <requireFileChecksum>
                                     <file>src/conf.d/rewrites/default_rewrite.rules</file>
-                                    <checksum>92800e1502954d8038b103f027cee332</checksum>
+                                    <checksum>8b866275685509537f6ab0397ddeda53</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/rewrites/default_rewrite.rules</message>
                                 </requireFileChecksum>
@@ -83,7 +83,7 @@
                                 </requireFileChecksum>
                                 <requireFileChecksum>
                                     <file>src/conf.dispatcher.d/cache/default_rules.any</file>
-                                    <checksum>daf2c7e3b81a862f5ee4f27b4c22de2f</checksum>
+                                    <checksum>bc9135f627dd2c813373950d7cb71af4</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/cache/default_rules.any</message>
                                 </requireFileChecksum>

--- a/dispatcher/src/conf.d/available_vhosts/default.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/default.vhost
@@ -17,7 +17,6 @@ Include conf.d/variables/custom.vars
 	ServerAlias	 "*"
 	# Use a document root that matches the one in conf.dispatcher.d/default.farm
 	DocumentRoot "${DOCROOT}"
-	DispatcherNoCanonURL 1
 	# URI dereferencing algorithm is applied at Sling's level, do not decode parameters here
 	AllowEncodedSlashes NoDecode
 	# Add header breadcrumbs for help in troubleshooting

--- a/dispatcher/src/conf.d/available_vhosts/default.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/default.vhost
@@ -17,6 +17,7 @@ Include conf.d/variables/custom.vars
 	ServerAlias	 "*"
 	# Use a document root that matches the one in conf.dispatcher.d/default.farm
 	DocumentRoot "${DOCROOT}"
+	DispatcherNoCanonURL 1
 	# URI dereferencing algorithm is applied at Sling's level, do not decode parameters here
 	AllowEncodedSlashes NoDecode
 	# Add header breadcrumbs for help in troubleshooting

--- a/dispatcher/src/conf.d/available_vhosts/default.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/default.vhost
@@ -61,6 +61,12 @@ Include conf.d/variables/custom.vars
 
 		# Rewrite index page internally, pass through (PT)
 		RewriteRule "^(/?)$" "/index.html" [PT]
-
 	</IfModule>
+
+    # Content Services/Sling Model Exporter: Cache for 5min with background refresh 1h on browser and 12h on CDN to avoid MISS
+    <LocationMatch "^/content/.*\.model\.json$">
+       Header set Cache-Control "max-age=300,stale-while-revalidate=3600" "expr=%{REQUEST_STATUS} < 400"
+       Header set Surrogate-Control "stale-while-revalidate=43200,stale-if-error=43200" "expr=%{REQUEST_STATUS} < 400"
+       Header set Age 0
+    </LocationMatch>
 </VirtualHost>

--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -14,7 +14,6 @@ Include conf.d/variables/custom.vars
 	ServerAlias	 "*"
 	# Use a document root that matches the one in conf.dispatcher.d/default.farm
 	DocumentRoot "${DOCROOT}"
-	DispatcherNoCanonURL 1
 	# URI dereferencing algorithm is applied at Sling's level, do not decode parameters here
 	AllowEncodedSlashes NoDecode
 	# Add header breadcrumbs for help in troubleshooting

--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -14,6 +14,7 @@ Include conf.d/variables/custom.vars
 	ServerAlias	 "*"
 	# Use a document root that matches the one in conf.dispatcher.d/default.farm
 	DocumentRoot "${DOCROOT}"
+	DispatcherNoCanonURL 1
 	# URI dereferencing algorithm is applied at Sling's level, do not decode parameters here
 	AllowEncodedSlashes NoDecode
 	# Add header breadcrumbs for help in troubleshooting

--- a/dispatcher/src/conf.d/dispatcher_vhost.conf
+++ b/dispatcher/src/conf.d/dispatcher_vhost.conf
@@ -10,12 +10,6 @@ ServerName dispatcher
 Include conf.d/variables/default.vars
 Include conf.d/variables/global.vars
 
-<IfDefine !DISABLE_DEFAULT_MOD_SECURITY_CONFIG>
-	<IfModule mod_security2.c>
-		Include conf.d/mod_security/mod_security.conf
-	</IfModule>
-</IfDefine>
-
 
 # WARNING!!! The probe paths below are INTERNAL and RESERVED - please DO NOT USE them in your virtual host configurations!
 
@@ -57,6 +51,16 @@ Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
     <LocationMatch "/content/test-site/">
         ProxyPassMatch http://${AEM_HOST}:${AEM_PORT}
         RewriteEngine Off
+    </LocationMatch>
+</IfDefine>
+
+# SITES-5185 - Ensure all GraphQL Queries to production publisher are using Persistent Queries and not direct query requests
+<IfDefine ENVIRONMENT_PROD>
+    SSLProxyEngine on
+    <LocationMatch "^/content/_cq_graphql/.*/endpoint.json$">
+        RewriteCond %{ENV:ENABLE_GRAPHQL_ENDPOINT} ^$ [OR]
+        RewriteCond %{ENV:ENABLE_GRAPHQL_ENDPOINT} ^false$
+        RewriteRule ^/(.*)$ - [R=404,L]
     </LocationMatch>
 </IfDefine>
 
@@ -136,64 +140,12 @@ Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
 	<IfDefine HTTP_EGRESS_PROXY>
 		ProxyRemote ${COMMERCE_ENDPOINT} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
 	</IfDefine>
-	<LocationMatch "/api/graphql(/default)?$">
-		# Use an empty back reference from ProxyPassMatch to the LocationMatch regex to prevent the
-		# original URL being appended to the proxy request
-		ProxyPassMatch   ${COMMERCE_ENDPOINT}$2
+	<LocationMatch "/api/graphql">
+		ProxyPass        ${COMMERCE_ENDPOINT}
 		ProxyPassReverse ${COMMERCE_ENDPOINT}
-		RewriteEngine 	 Off
+		RewriteEngine Off
 	</LocationMatch>
 </IfDefine>
-<IfDefine COMMERCE_ENDPOINT_2>
-	SSLProxyEngine on
-	<IfDefine HTTP_EGRESS_PROXY>
-		ProxyRemote ${AEM_COMMERCE_ENDPOINT_2} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
-	</IfDefine>
-	<LocationMatch "/api/graphql/endpoint-2$">
-		ProxyPassMatch   ${AEM_COMMERCE_ENDPOINT_2}$2
-		ProxyPassReverse ${AEM_COMMERCE_ENDPOINT_2}
-		RewriteEngine 	 Off
-	</LocationMatch>
-</IfDefine>
-<IfDefine COMMERCE_ENDPOINT_3>
-	SSLProxyEngine on
-	<IfDefine HTTP_EGRESS_PROXY>
-		ProxyRemote ${AEM_COMMERCE_ENDPOINT_3} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
-	</IfDefine>
-	<LocationMatch "/api/graphql/endpoint-3$">
-		ProxyPassMatch	 ${AEM_COMMERCE_ENDPOINT_3}$2
-		ProxyPassReverse ${AEM_COMMERCE_ENDPOINT_3}
-		RewriteEngine 	 Off
-	</LocationMatch>
-</IfDefine>
-<IfDefine COMMERCE_ENDPOINT_4>
-	SSLProxyEngine on
-	<IfDefine HTTP_EGRESS_PROXY>
-		ProxyRemote ${AEM_COMMERCE_ENDPOINT_4} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
-	</IfDefine>
-	<LocationMatch "/api/graphql/endpoint-4$">
-		ProxyPassMatch	 ${AEM_COMMERCE_ENDPOINT_4}$2
-		ProxyPassReverse ${AEM_COMMERCE_ENDPOINT_4}
-		RewriteEngine 	 Off
-	</LocationMatch>
-</IfDefine>
-<IfDefine COMMERCE_ENDPOINT_5>
-	SSLProxyEngine on
-	<IfDefine HTTP_EGRESS_PROXY>
-		ProxyRemote ${AEM_COMMERCE_ENDPOINT_5} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
-	</IfDefine>
-	<LocationMatch "/api/graphql/endpoint-5$">
-		ProxyPassMatch	 ${AEM_COMMERCE_ENDPOINT_5}$2
-		ProxyPassReverse ${AEM_COMMERCE_ENDPOINT_5}
-		RewriteEngine 	 Off
-	</LocationMatch>
-</IfDefine>
-
-# ASSETS-10359 Prevent rewrites and filtering of Delivery API URLs
-<LocationMatch "^/adobe/dynamicmedia/deliver/.*">
-    ProxyPassMatch http://${AEM_HOST}:${AEM_PORT}
-    RewriteEngine Off
-</LocationMatch>
 
 # Disable access to default CGI scripts
 <Directory "/var/www/localhost/cgi-bin">
@@ -215,7 +167,7 @@ Alias "/gitinit-status" /etc/httpd/metadata/gitinit-status.json
     Require expr "%{HTTP_HOST} == '${POD_NAME}'"
 </Directory>
 
-Include conf.d/enabled_vhosts/vhosts.conf
+Include conf.d/enabled_vhosts/*.vhost
 
 # Create a catch-all vhost
 # A catch-all is a safe place for un-matched hostnames to land.

--- a/dispatcher/src/conf.d/dispatcher_vhost.conf
+++ b/dispatcher/src/conf.d/dispatcher_vhost.conf
@@ -10,6 +10,12 @@ ServerName dispatcher
 Include conf.d/variables/default.vars
 Include conf.d/variables/global.vars
 
+<IfDefine !DISABLE_DEFAULT_MOD_SECURITY_CONFIG>
+	<IfModule mod_security2.c>
+		Include conf.d/mod_security/mod_security.conf
+	</IfModule>
+</IfDefine>
+
 
 # WARNING!!! The probe paths below are INTERNAL and RESERVED - please DO NOT USE them in your virtual host configurations!
 
@@ -51,24 +57,6 @@ Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
     <LocationMatch "/content/test-site/">
         ProxyPassMatch http://${AEM_HOST}:${AEM_PORT}
         RewriteEngine Off
-    </LocationMatch>
-</IfDefine>
-
-# SITES-5185 - Ensure all GraphQL Queries to production publisher are using Persistent Queries and not direct query requests
-<IfDefine ENVIRONMENT_PROD>
-    SSLProxyEngine on
-    <LocationMatch "^/content/_cq_graphql/.*/endpoint.json$">
-        RewriteCond %{ENV:ENABLE_GRAPHQL_ENDPOINT} ^$ [OR]
-        RewriteCond %{ENV:ENABLE_GRAPHQL_ENDPOINT} ^false$
-        RewriteRule ^/(.*)$ - [R=404,L]
-    </LocationMatch>
-</IfDefine>
-<IfDefine ENVIRONMENT_STAGE>
-    SSLProxyEngine on
-    <LocationMatch "^/content/_cq_graphql/.*/endpoint.json$">
-        RewriteCond %{ENV:ENABLE_GRAPHQL_ENDPOINT} ^$ [OR]
-        RewriteCond %{ENV:ENABLE_GRAPHQL_ENDPOINT} ^false$
-        RewriteRule ^/(.*)$ - [R=404,L]
     </LocationMatch>
 </IfDefine>
 
@@ -116,6 +104,11 @@ Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
 	Header unset Age
 </IfDefine>
 
+# SITES-3659 Prevent re-encodes of URLs sent to GraphQL Persisted Queries API endpoint
+<LocationMatch "/graphql/execute.json/.*">
+    ProxyPassMatch http://${AEM_HOST}:${AEM_PORT} nocanon
+</LocationMatch>
+
 # (legacy) Allow ingressroute checks through on /systemready (regardless of dispatcher filters)
 <Location "/systemready">
 	ProxyPass http://${AEM_HOST}:${AEM_PORT}/systemready
@@ -143,12 +136,64 @@ Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
 	<IfDefine HTTP_EGRESS_PROXY>
 		ProxyRemote ${COMMERCE_ENDPOINT} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
 	</IfDefine>
-	<LocationMatch "/api/graphql">
-		ProxyPass        ${COMMERCE_ENDPOINT}
+	<LocationMatch "/api/graphql(/default)?$">
+		# Use an empty back reference from ProxyPassMatch to the LocationMatch regex to prevent the
+		# original URL being appended to the proxy request
+		ProxyPassMatch   ${COMMERCE_ENDPOINT}$2
 		ProxyPassReverse ${COMMERCE_ENDPOINT}
-		RewriteEngine Off
+		RewriteEngine 	 Off
 	</LocationMatch>
 </IfDefine>
+<IfDefine COMMERCE_ENDPOINT_2>
+	SSLProxyEngine on
+	<IfDefine HTTP_EGRESS_PROXY>
+		ProxyRemote ${AEM_COMMERCE_ENDPOINT_2} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
+	</IfDefine>
+	<LocationMatch "/api/graphql/endpoint-2$">
+		ProxyPassMatch   ${AEM_COMMERCE_ENDPOINT_2}$2
+		ProxyPassReverse ${AEM_COMMERCE_ENDPOINT_2}
+		RewriteEngine 	 Off
+	</LocationMatch>
+</IfDefine>
+<IfDefine COMMERCE_ENDPOINT_3>
+	SSLProxyEngine on
+	<IfDefine HTTP_EGRESS_PROXY>
+		ProxyRemote ${AEM_COMMERCE_ENDPOINT_3} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
+	</IfDefine>
+	<LocationMatch "/api/graphql/endpoint-3$">
+		ProxyPassMatch	 ${AEM_COMMERCE_ENDPOINT_3}$2
+		ProxyPassReverse ${AEM_COMMERCE_ENDPOINT_3}
+		RewriteEngine 	 Off
+	</LocationMatch>
+</IfDefine>
+<IfDefine COMMERCE_ENDPOINT_4>
+	SSLProxyEngine on
+	<IfDefine HTTP_EGRESS_PROXY>
+		ProxyRemote ${AEM_COMMERCE_ENDPOINT_4} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
+	</IfDefine>
+	<LocationMatch "/api/graphql/endpoint-4$">
+		ProxyPassMatch	 ${AEM_COMMERCE_ENDPOINT_4}$2
+		ProxyPassReverse ${AEM_COMMERCE_ENDPOINT_4}
+		RewriteEngine 	 Off
+	</LocationMatch>
+</IfDefine>
+<IfDefine COMMERCE_ENDPOINT_5>
+	SSLProxyEngine on
+	<IfDefine HTTP_EGRESS_PROXY>
+		ProxyRemote ${AEM_COMMERCE_ENDPOINT_5} "http://${AEM_HTTP_PROXY_HOST}:${AEM_HTTP_PROXY_PORT}"
+	</IfDefine>
+	<LocationMatch "/api/graphql/endpoint-5$">
+		ProxyPassMatch	 ${AEM_COMMERCE_ENDPOINT_5}$2
+		ProxyPassReverse ${AEM_COMMERCE_ENDPOINT_5}
+		RewriteEngine 	 Off
+	</LocationMatch>
+</IfDefine>
+
+# ASSETS-10359 Prevent rewrites and filtering of Delivery API URLs
+<LocationMatch "^/adobe/dynamicmedia/deliver/.*">
+    ProxyPassMatch http://${AEM_HOST}:${AEM_PORT}
+    RewriteEngine Off
+</LocationMatch>
 
 # Disable access to default CGI scripts
 <Directory "/var/www/localhost/cgi-bin">
@@ -170,7 +215,7 @@ Alias "/gitinit-status" /etc/httpd/metadata/gitinit-status.json
     Require expr "%{HTTP_HOST} == '${POD_NAME}'"
 </Directory>
 
-Include conf.d/enabled_vhosts/*.vhost
+Include conf.d/enabled_vhosts/vhosts.conf
 
 # Create a catch-all vhost
 # A catch-all is a safe place for un-matched hostnames to land.

--- a/dispatcher/src/conf.d/rewrites/default_rewrite.rules
+++ b/dispatcher/src/conf.d/rewrites/default_rewrite.rules
@@ -37,3 +37,7 @@ RewriteRule .* - [F]
 
 # Block wp-login
 RewriteRule ^.*wp-login - [F,NC,L]
+
+# Allow caching of persisted queries
+RewriteCond %{REQUEST_URI} ^/graphql/execute.json
+RewriteRule ^/(.*)$ /$1;.json [PT,L]

--- a/dispatcher/src/conf.dispatcher.d/cache/default_rules.any
+++ b/dispatcher/src/conf.dispatcher.d/cache/default_rules.any
@@ -38,9 +38,3 @@
 	/glob "/screens/channels.json"
 	/type "deny"
 }
-
-# GraphQL cache rules for persistent queries
-/0020 {
-    /glob "/graphql/execute.json/*"
-    /type "deny"
-}


### PR DESCRIPTION
GraphQL persisted queries should be cached by default at dispatcher level.

##Description

The query parameters sent in the request via dispatcher need to be encoded. One example of such query is
https://publish-p33706-e135212.adobeaemcloud.com/graphql/execute.json/aem-cplotusonlinecommerce-project/getMarketingBannersList%3Btag%3Dmarketing-banner-homepage%3Bpath%3D%2Fcontent%2Fdam%2Faem-cplotusonlinecommerce-project%2Fth%2Fen%2Fhome

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
