### PR TITLE
SITES-3659 - [Odin] Review Dispatcher config for Odin and contribute generic parts - Persisted queries

### DIFF
--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -59,13 +59,13 @@
                                 </requireFileChecksum>
                                 <requireFileChecksum>
                                     <file>src/conf.d/dispatcher_vhost.conf</file>
-                                    <checksum>b30900e92c6995dfa6c68efcf159f4f0</checksum>
+                                    <checksum>b27855383754854932170e282fbf643a</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/dispatcher_vhost.conf</message>
                                 </requireFileChecksum>
                                 <requireFileChecksum>
                                     <file>src/conf.d/rewrites/default_rewrite.rules</file>
-                                    <checksum>92800e1502954d8038b103f027cee332</checksum>
+                                    <checksum>8b866275685509537f6ab0397ddeda53</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/rewrites/default_rewrite.rules</message>
                                 </requireFileChecksum>
@@ -83,7 +83,7 @@
                                 </requireFileChecksum>
                                 <requireFileChecksum>
                                     <file>src/conf.dispatcher.d/cache/default_rules.any</file>
-                                    <checksum>daf2c7e3b81a862f5ee4f27b4c22de2f</checksum>
+                                    <checksum>bc9135f627dd2c813373950d7cb71af4</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/cache/default_rules.any</message>
                                 </requireFileChecksum>

--- a/dispatcher/src/conf.d/dispatcher_vhost.conf
+++ b/dispatcher/src/conf.d/dispatcher_vhost.conf
@@ -63,14 +63,6 @@ Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
         RewriteRule ^/(.*)$ - [R=404,L]
     </LocationMatch>
 </IfDefine>
-<IfDefine ENVIRONMENT_STAGE>
-    SSLProxyEngine on
-    <LocationMatch "^/content/_cq_graphql/.*/endpoint.json$">
-        RewriteCond %{ENV:ENABLE_GRAPHQL_ENDPOINT} ^$ [OR]
-        RewriteCond %{ENV:ENABLE_GRAPHQL_ENDPOINT} ^false$
-        RewriteRule ^/(.*)$ - [R=404,L]
-    </LocationMatch>
-</IfDefine>
 
 # If the module loads correctly then apply base settings for the module
 <IfModule disp_apache2.c>
@@ -115,6 +107,11 @@ Alias "/system/probes/start" /etc/httpd/probes/startup-status.json
 	</IfModule>
 	Header unset Age
 </IfDefine>
+
+# SITES-3659 Prevent re-encodes of URLs sent to GraphQL Persisted Queries API endpoint
+<LocationMatch "/graphql/execute.json/.*">
+    ProxyPassMatch http://${AEM_HOST}:${AEM_PORT} nocanon
+</LocationMatch>
 
 # (legacy) Allow ingressroute checks through on /systemready (regardless of dispatcher filters)
 <Location "/systemready">

--- a/dispatcher/src/conf.d/rewrites/default_rewrite.rules
+++ b/dispatcher/src/conf.d/rewrites/default_rewrite.rules
@@ -37,3 +37,7 @@ RewriteRule .* - [F]
 
 # Block wp-login
 RewriteRule ^.*wp-login - [F,NC,L]
+
+# Allow caching of persisted queries
+RewriteCond %{REQUEST_URI} ^/graphql/execute.json
+RewriteRule ^/(.*)$ /$1;.json [PT,L]

--- a/dispatcher/src/conf.dispatcher.d/cache/default_rules.any
+++ b/dispatcher/src/conf.dispatcher.d/cache/default_rules.any
@@ -38,9 +38,3 @@
 	/glob "/screens/channels.json"
 	/type "deny"
 }
-
-# GraphQL cache rules for persistent queries
-/0020 {
-    /glob "/graphql/execute.json/*"
-    /type "deny"
-}


### PR DESCRIPTION
GraphQL persisted queries should be cached by default at dispatcher level.

## Description

The query parameters sent in the request via dispatcher need to be encoded. One example of such query is
https://publish-p33706-e135212.adobeaemcloud.com/graphql/execute.json/aem-cplotusonlinecommerce-project/getMarketingBannersList%3Btag%3Dmarketing-banner-homepage%3Bpath%3D%2Fcontent%2Fdam%2Faem-cplotusonlinecommerce-project%2Fth%2Fen%2Fhome

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
