### PR TITLE
SITES-10562 - Embed Youtube component not honoring Aspect ratio

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-base/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-base/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[wknd.base]"
-    embed="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v3,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2]"/>
+    embed="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v3,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.embed.v1]"/>


### PR DESCRIPTION
- add core.wcm.components.embed.v1 dependency to site.base clientlib to enable responsive behaviour for the youtube embed. 