### PR TITLE
Disable lazy loading on images to reduce CLS

### DIFF
--- a/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/wknd/settings/wcm/policies/.content.xml
@@ -466,7 +466,7 @@
                     allowedRenditionWidths="[100,200,300,400,500,600,700,800,900,1000,1100,1200,1600]"
                     allowUpload="true"
                     altValueFromDAM="true"
-                    disableLazyLoading="false"
+                    disableLazyLoading="true"
                     displayPopupTitle="true"
                     enableAssetDelivery="true"
                     isDecorative="false"


### PR DESCRIPTION
Disable lazy loading on Core Components image policy to increase LHS score by reducing CLS.

## Description

Disabled lazy loading.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Increase pagespeed/LHS.

## How Has This Been Tested?

In Summit lab.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
