### PR TITLE
Update breakpoint to match editor tablet emulator width

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-grid/less/grid.less
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/clientlibs/clientlib-grid/less/grid.less
@@ -25,14 +25,14 @@
 }
 
 /* phone breakpoint */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .aem-Grid {
     .generate-grid(phone, @max_col);
   }
 }
 
 /* tablet breakpoint */
-@media (min-width: 769px) and (max-width: 1200px) {
+@media (min-width: 768px) and (max-width: 1200px) {
   .aem-Grid {
     .generate-grid(tablet, @max_col);
   }

--- a/ui.frontend/src/main/webpack/base/sass/_variables.scss
+++ b/ui.frontend/src/main/webpack/base/sass/_variables.scss
@@ -37,7 +37,7 @@ $gutter-padding: 14px;
 $max-width: 1164px;
 $max-body-width: 1680px;
 $screen-xsmall: 475px;
-$screen-small: 768px;
+$screen-small: 767px;
 $screen-medium: 1024px;
 $screen-large: 1200px;
 


### PR DESCRIPTION
Update breakpoint to match editor tablet emulator width

## Description

Emulator width for tablet in editor is 768px. Since this is the phone breakpoint in the css and variables in wknd, tablet breakpoint gets set to 769px and hence the appropriate styles for tablet are not getting applied in the emulator.


## Motivation and Context

Layout updates can be done in tablet emulator mode in AEM CS page editor.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
