### PR TITLE
Resolved package dependency in classic all project

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -193,6 +193,9 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
+            <properties>
+                <wknd-shared.version>${wknd-shared.65.version}</wknd-shared.version>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -265,7 +268,7 @@
                 <dependency>
                     <groupId>com.adobe.aem.guides</groupId>
                     <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
-                    <version>${wknd-shared.65.version}</version>
+                    <version>${wknd-shared.version}</version>
                     <type>zip</type>
                 </dependency>        
             </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -160,7 +160,6 @@ Import-Package: javax.annotation;version=0.0.0,*
         </profile>
         <profile>
             <id>classic</id>
-
              <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -453,6 +453,7 @@ Bundle-DocURL:
     </build>
 
     <profiles>
+  
         <!-- ====================================================== -->
         <!-- A D O B E P U B L I C P R O F I L E -->
         <!-- ====================================================== -->
@@ -715,6 +716,7 @@ Bundle-DocURL:
                 </plugins>
             </build>
         </profile>
+
     </profiles>
 
 

--- a/ui.content.sample/pom.xml
+++ b/ui.content.sample/pom.xml
@@ -71,7 +71,6 @@
                         <dependency>
                             <groupId>com.adobe.aem.guides</groupId>
                             <artifactId>aem-guides-wknd-shared.ui.content</artifactId>
-                            <version>${wknd-shared.version}</version>
                         </dependency>
                     </dependencies>
                 </configuration>
@@ -116,4 +115,13 @@
             <type>zip</type>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>classic</id>
+            <properties>
+                <wknd-shared.version>${wknd-shared.65.version}</wknd-shared.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -116,4 +116,13 @@
             <artifactId>aem-sdk-api</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>classic</id>
+            <properties>
+                <wknd-shared.version>${wknd-shared.65.version}</wknd-shared.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Fixed issue where aem-guides-wknd-shared.ui.content v3.0.0 was being set as a package dependency even in the `-classic` artifact.

This fix sets aem-guides-wknd-shared.ui.content v3.0.0 as a dep in the cloud artifact, and v2.2.2 as a dep in the classic artifact.
 
Note that the aem-guides-wknd.all-3.0.0-classic.zip in https://github.com/adobe/aem-guides-wknd/releases/tag/aem-guides-wknd-3.0.0 contains this fix retroactively.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
