### PR TITLE
Target xf css issue

### DIFF
--- a/ui.frontend/src/main/webpack/site/elements.scss
+++ b/ui.frontend/src/main/webpack/site/elements.scss
@@ -44,7 +44,13 @@ body.xf-web-container {
   }
 }
 
+/* remove padding for experience fragments imported into Adobe Target */
 
+div.at-element-marker {
+  .root{
+    padding-top: $gutter-padding;
+  }
+}
 
 // Headings
 // -------------------------


### PR DESCRIPTION
When using the WKND XFs in Target on a WKND page, the HTML imported into Target contains:
```
<body class="xf-web-container">
 <div class="container">
    <div class="root container responsivegrid">
      <div id="container-d5e81cbcff" class="cmp-container">
         ...
```
WKND's css library uses `body .root {` to set spacing at the top of the WKND site with elements.scss:
```
body {
 ...
  .root {
     max-width: $max-body-width;
     margin: 0 auto;
     padding-top:$header-height;
     ...
```
When a WKND XF is added to a WKND page using the VEC with an imported XF from AEM, the css above is applied to the XF and therefore the component padding-top is set to $header-height.

![image](https://github.com/adobe/aem-guides-wknd/assets/2186704/cbaec8cf-f233-4198-90ba-0b5cf6d79201)

This can be fixed by fixing the template-type and template for the WKND experience fragment template.

## Description

Under ui.content.sample and ui.content the `root` nodes are updated to `xf-root`:
  * conf/wknd/settings/wcm/template-types/empty-experience-fragment
  * conf/wknd/settings/wcm/templates/experience-fragment-web-variation-template 
  * content/experience-fragments/wknd (all fragments)

This allows the WKND XFs to be imported into Target without the root class and therefor, the padding is not applied:
```
<body class="xf-web-container">
 <div class="container">
    <div class="xf-root container responsivegrid">
      <div id="container-d5e81cbcff" class="cmp-container">
         ...
```

![image](https://github.com/adobe/aem-guides-wknd/assets/2186704/38ecb51f-acb9-4561-b1f4-321ab1cfde31)

## Motivation and Context

This allows anyone to use WKND as a reference website for the AEM XF and Adobe Target integration flawlessly.

Someone can now use the pre-created XF content in WKND and apply it successfully and beautifully to the WKND site using Adobe Target without the components 'jumping around' on the page.

## How Has This Been Tested?

All tested locally on 2023.06 SDK
- [x] Extra padding disappears when adding an imported WKND experience fragment to the WKND website
- [x] successfully create a new XF template from the XF template type
- [x] successfully use a new XF template
- [x] successfully use the current XF template
- [x] All experience fragments visually look correct in the experience fragment editor
- [x] All pages with XFs visually look correct

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
