### PR TITLE
Fixed IT Tests to handle updated GQL queries in WKND Shared 3.x

### DIFF
--- a/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
+++ b/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
@@ -186,12 +186,12 @@ public class GraphQlIT {
         JsonNode adventureListItems = adventureListList.get("items");
         assertNotNull(adventureListItems);
         assertEquals(16, adventureListItems.size());
-        JsonNode firstAdvantureItem = adventureListItems.get(0);
-        assertNotNull(firstAdvantureItem.get("_path"));
-        assertNotNull(firstAdvantureItem.get("title"));
-        assertNotNull(firstAdvantureItem.get("price"));
-        assertNotNull(firstAdvantureItem.get("tripLength"));
-        assertNotNull(firstAdvantureItem.get("primaryImage"));
+        JsonNode firstAdventureItem = adventureListItems.get(0);
+        assertNotNull(firstAdventureItem.get("_path"));
+        assertNotNull(firstAdventureItem.get("title"));
+        assertNotNull(firstAdventureItem.get("price"));
+        assertNotNull(firstAdventureItem.get("tripLength"));
+        assertNotNull(firstAdventureItem.get("primaryImage"));
 
     }
 
@@ -203,6 +203,6 @@ public class GraphQlIT {
         PersistedQuery adventuresQuery = listPersistedQueries.stream()
                 .filter(p -> p.getShortPath().equals("/wknd-shared/adventures-all")).findFirst().get();
         assertEquals("/wknd-shared/settings/graphql/persistentQueries/adventures-all", adventuresQuery.getLongPath());
-        assertThat(adventuresQuery.getQuery(), containsString("adventureList {"));
+        assertThat(adventuresQuery.getQuery(), containsString("adventureList") );
     }
 }

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -125,4 +125,5 @@
             </properties>
         </profile>
     </profiles>
+    
 </project>


### PR DESCRIPTION
## Description

GraphQL IT tests failing in WKND project due to change in signature of Persisted Queries in WKND Shared 3.x.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Testing on AEM as a Cloud Service Production pipeline deployment.


```
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------< com.adobe.evergreen.eaas:eaas-test-runner >--------------
[INFO] Building EaaS tests runner 1.0.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] Downloading from shared: file:///shared/m2-repo/com/adobe/aem/cloud/custom-module/0.0.0/custom-module-0.0.0.pom
[INFO] Downloaded from shared: file:///shared/m2-repo/com/adobe/aem/cloud/custom-module/0.0.0/custom-module-0.0.0.pom (379 B at 2.0 kB/s)
[INFO] Downloading from shared: file:///shared/m2-repo/com/adobe/aem/cloud/custom-module/0.0.0/custom-module-0.0.0-jar-with-dependencies.jar
[INFO] Downloaded from shared: file:///shared/m2-repo/com/adobe/aem/cloud/custom-module/0.0.0/custom-module-0.0.0-jar-with-dependencies.jar (24 MB at 22 MB/s)
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M7:integration-test (default-cli) @ eaas-test-runner ---
[INFO] Using configured provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] Downloading from shared: file:///shared/m2-repo/org/junit/jupiter/junit-jupiter-engine/5.3.2/junit-jupiter-engine-5.3.2.pom
[WARNING] Missing POM for org.junit.jupiter:junit-jupiter-engine:jar:5.3.2
[INFO] Downloading from shared: file:///shared/m2-repo/org/junit/jupiter/junit-jupiter-params/5.3.2/junit-jupiter-params-5.3.2.pom
[WARNING] Missing POM for org.junit.jupiter:junit-jupiter-params:jar:5.3.2
[INFO] Downloading from shared: file:///shared/m2-repo/org/mockito/mockito-core/2.28.2/mockito-core-2.28.2.pom
[WARNING] Missing POM for org.mockito:mockito-core:jar:2.28.2
[INFO] Downloading from shared: file:///shared/m2-repo/org/powermock/powermock-reflect/2.0.9/powermock-reflect-2.0.9.pom
[WARNING] Missing POM for org.powermock:powermock-reflect:jar:2.0.9
[INFO] Downloading from shared: file:///shared/m2-repo/org/hamcrest/hamcrest-library/1.3/hamcrest-library-1.3.pom
[WARNING] Missing POM for org.hamcrest:hamcrest-library:jar:1.3
[INFO] Downloading from shared: file:///shared/m2-repo/org/assertj/assertj-core/3.22.0/assertj-core-3.22.0.pom
[WARNING] Missing POM for org.assertj:assertj-core:jar:3.22.0
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.adobe.aem.guides.wknd.it.tests.GraphQlIT
[main] INFO com.adobe.cq.testing.junit.rules.ConfigurableInstance - Using instances with config: [authentication method: LoginToken, indexing lanes detection: false]
[main] INFO com.adobe.cq.testing.junit.rules.ConfigurableInstance - Using instances with config: [authentication method: LoginToken, indexing lanes detection: false]
[main] INFO org.apache.sling.testing.junit.rules.instance.util.ConfigurationPool - Reading initial configurations from the system properties
[main] INFO org.apache.sling.testing.junit.rules.instance.util.ConfigurationPool - Found 2 instance configuration(s) from the system properties
[main] INFO org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement - InstanceConfiguration (URL: https://author-p63947-e603363.adobeaemcloud.net, runmode: author) found for test com.adobe.aem.guides.wknd.it.tests.GraphQlIT
[main] INFO org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement - InstanceConfiguration (URL: https://publish-p63947-e603363.adobeaemcloud.net, runmode: publish) found for test com.adobe.aem.guides.wknd.it.tests.GraphQlIT
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.473 s - in com.adobe.aem.guides.wknd.it.tests.GraphQlIT
[INFO] Running com.adobe.aem.guides.wknd.it.tests.GraphQLEndpointIT
[main] INFO com.adobe.cq.testing.junit.rules.ConfigurableInstance - Using instances with config: [authentication method: LoginToken, indexing lanes detection: false]
[main] INFO com.adobe.cq.testing.junit.rules.ConfigurableInstance - Using instances with config: [authentication method: LoginToken, indexing lanes detection: false]
[main] INFO org.apache.sling.testing.junit.rules.instance.util.ConfigurationPool - Reading initial configurations from the system properties
[main] INFO org.apache.sling.testing.junit.rules.instance.util.ConfigurationPool - Found 2 instance configuration(s) from the system properties
[main] INFO org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement - InstanceConfiguration (URL: https://author-p63947-e603363.adobeaemcloud.net, runmode: author) found for test com.adobe.aem.guides.wknd.it.tests.GraphQLEndpointIT
[main] INFO org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement - InstanceConfiguration (URL: https://publish-p63947-e603363.adobeaemcloud.net, runmode: publish) found for test com.adobe.aem.guides.wknd.it.tests.GraphQLEndpointIT
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.669 s - in com.adobe.aem.guides.wknd.it.tests.GraphQLEndpointIT
[INFO] Running com.adobe.aem.guides.wknd.it.tests.GetPageIT
[main] INFO com.adobe.cq.testing.junit.rules.ConfigurableInstance - Using instances with config: [authentication method: LoginToken, indexing lanes detection: false]
[main] INFO com.adobe.cq.testing.junit.rules.ConfigurableInstance - Using instances with config: [authentication method: LoginToken, indexing lanes detection: false]
[main] INFO org.apache.sling.testing.junit.rules.instance.util.ConfigurationPool - Reading initial configurations from the system properties
[main] INFO org.apache.sling.testing.junit.rules.instance.util.ConfigurationPool - Found 2 instance configuration(s) from the system properties
[main] INFO org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement - InstanceConfiguration (URL: https://author-p63947-e603363.adobeaemcloud.net, runmode: author) found for test com.adobe.aem.guides.wknd.it.tests.GetPageIT
[main] INFO org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement - InstanceConfiguration (URL: https://publish-p63947-e603363.adobeaemcloud.net, runmode: publish) found for test com.adobe.aem.guides.wknd.it.tests.GetPageIT
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.59 s - in com.adobe.aem.guides.wknd.it.tests.GetPageIT
[INFO] Running com.adobe.aem.guides.wknd.it.tests.PublishPageValidationIT
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.097 s - in com.adobe.aem.guides.wknd.it.tests.PublishPageValidationIT
[INFO] Running com.adobe.aem.guides.wknd.it.tests.CreatePageIT
[main] INFO com.adobe.cq.testing.junit.rules.ConfigurableInstance - Using instances with config: [authentication method: LoginToken, indexing lanes detection: false]
[main] INFO org.apache.sling.testing.junit.rules.instance.util.ConfigurationPool - Reading initial configurations from the system properties
[main] INFO org.apache.sling.testing.junit.rules.instance.util.ConfigurationPool - Found 2 instance configuration(s) from the system properties
[main] INFO org.apache.sling.testing.junit.rules.instance.ExistingInstanceStatement - InstanceConfiguration (URL: https://author-p63947-e603363.adobeaemcloud.net, runmode: author) found for test com.adobe.aem.guides.wknd.it.tests.CreatePageIT
[main] INFO com.adobe.cq.testing.junit.rules.Page - Created page at /content/test-site/testpage_c911eb2d-b522-45bf-8a7c-7eafadff1eaf
[main] INFO com.adobe.cq.testing.junit.rules.Page - Deleted page at /content/test-site/testpage_c911eb2d-b522-45bf-8a7c-7eafadff1eaf
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.846 s - in com.adobe.aem.guides.wknd.it.tests.CreatePageIT
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 14, Failures: 0, Errors: 0, Skipped: 1
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  41.236 s
[INFO] Finished at: 2023-08-28T19:07:00Z
[INFO] ------------------------------------------------------------------------
```

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
