### PR TITLE
Add CDN configuration

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,5 @@
+# AEM as a Cloud Service Configuration Files
+
+This folder contains service's configuration files that you can deploy on your AEM as a Cloud Service environment from Cloud Manager using Configuration Pipeline.
+
+For now only CDN Traffic Filters Rules and WAF rules can be configured. You can learn more about Traffic Filters Rules and WAF rules in [our online documentation](https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/security/cdn-and-waf-rules.html).

--- a/config/cdn.yaml
+++ b/config/cdn.yaml
@@ -1,0 +1,49 @@
+kind: "CDN"
+version: "1"
+metadata:
+  envTypes: ["dev"]
+data:
+  trafficFilters:
+    rules:
+      # Block access to a given path
+      # - name: block-path
+      #   when:
+      #     allOf:
+      #       - reqProperty: tier
+      #         matches: "author|publish"
+      #       - reqProperty: path
+      #         equals: '/block/me'
+      #   action: block
+      # Block access to OFAC countries
+      - name: block-ofac-countries
+        when:
+          allOf:
+            - reqProperty: tier
+              matches: "author|publish"
+            - reqProperty: clientCountry
+              in:
+                - SY
+                - BY
+                - MM
+                - KP
+                - IQ
+                - CD
+                - SD
+                - IR
+                - LR
+                - ZW
+                - CU
+                - CI
+        action: block
+      # Block client for 5m when it exceeds 100 req/sec on a time window of 1sec
+      - name: limit-requests-per-client-ip
+        when:
+          reqProperty: tier
+          matches: "author|publish"
+        rateLimit:
+          limit: 100
+          window: 1
+          penalty: 300
+          groupBy:
+            - reqProperty: clientIp
+        action: block


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a configuration folder that includes an example of CDN configuration file. 
It is only meant as a good practise example related to https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/security/cdn-and-waf-rules.html.

**Notes:** This configuration folder is only useful in the context of AEM as a Cloud Service

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
