### PR TITLE
sync dispatcher immutable files with Dispatcher SDK and image v2.0.191

### DIFF
--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -59,7 +59,7 @@
                                 </requireTextFileChecksum>
                                 <requireTextFileChecksum>
                                     <file>src/conf.d/dispatcher_vhost.conf</file>
-                                    <checksum>b355146c776800f903f1bf8d164ad495</checksum>
+                                    <checksum>8be9f535a8a4d15bd895cebb2a9e03ad</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/dispatcher_vhost.conf</message>
                                 </requireTextFileChecksum>
@@ -113,7 +113,7 @@
                                 </requireTextFileChecksum>
                                 <requireTextFileChecksum>
                                     <file>src/conf.dispatcher.d/filters/default_filters.any</file>
-                                    <checksum>8a99566bdabbc11061a6cbaf0f14cecc</checksum>
+                                    <checksum>33ab21977347e87a04dac059cd15fc06</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/filters/default_filters.any</message>
                                 </requireTextFileChecksum>

--- a/dispatcher/src/conf.d/dispatcher_vhost.conf
+++ b/dispatcher/src/conf.d/dispatcher_vhost.conf
@@ -60,7 +60,12 @@ Alias "/system/probes/start" probes/startup-status.json
 	DispatcherConfig conf.dispatcher.d/dispatcher.any
 
 	# Format for the dispatcher log file
-	LogFormat "%t \"%m %{dispatcher:uri}e%q %H\" %{dispatcher:status}e %{dispatcher:cache}e [%{dispatcher:backend}e] %{ms}Tms \"%{Host}i\"" dispatcher
+	<IfDefine !LOG_X_REQUEST_ID>
+		LogFormat "%t \"%m %{dispatcher:uri}e%q %H\" %{dispatcher:status}e %{dispatcher:cache}e [%{dispatcher:backend}e] %{ms}Tms \"%{Host}i\"" dispatcher
+	</IfDefine>
+	<IfDefine LOG_X_REQUEST_ID>
+		LogFormat "%t \"%m %{dispatcher:uri}e%q %H\" %{dispatcher:status}e %{dispatcher:cache}e [%{dispatcher:backend}e] %{ms}Tms \"%{Host}i\" \"%{x-request-id}i\"" dispatcher
+	</IfDefine>
 	CustomLog "| /usr/sbin/rotatelogs -e -f -t logs/dispatcher.log 86400" dispatcher "expr=%{HANDLER} == 'dispatcher-handler'"
 
 	# Log level for the dispatcher module

--- a/dispatcher/src/conf.dispatcher.d/filters/default_filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/default_filters.any
@@ -98,3 +98,6 @@
 
 # Allow Forms Document Services requests
 /0062 { /type "allow" /method '(GET|POST)' /url "/adobe/forms/*" }
+
+# Allow PUT for Forms DocAssurance Services Decryption API
+/0063 { /type "allow" /method "PUT" /url "/adobe/forms/document/assure/encrypt" }


### PR DESCRIPTION
sync dispatcher immutable files with Dispatcher SDK and image v2.0.191

## Description

Since the previous sync of dispatcher immutable files with Dispatcher SDK and image was from version 2.0.166 in March 2023 and AEM CS releases already progressed further, including dispatcher image and SDK tooling containing newer files, it resulted already in customer using latest public AEM CS releases being out of sync and reporting issues like https://github.com/adobe/aem-project-archetype/issues/1043

Hence we propose to sync those files with the ones from the latest Dispatcher SDK and image v2.0.191 in order for validation scripts not to fail in immutable files compatibility check step as described in https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/validation-debug.html?lang=en#third-phase

## Related Issue

* https://github.com/adobe/aem-project-archetype/issues/1043
* https://github.com/adobe/aem-project-archetype/pull/1141

## Motivation and Context

Not to fail immutable files validation step described in https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/validation-debug.html?lang=en#third-phase when using Dispatcher SDK tooling from the latest AEM CS releases.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
