### PR TITLE
Enable Open API calls to wknd publish (at least dev.wknd.site)

### DIFF
--- a/dispatcher/src/conf.dispatcher.d/clientheaders/clientheaders.any
+++ b/dispatcher/src/conf.dispatcher.d/clientheaders/clientheaders.any
@@ -7,4 +7,7 @@
 # Allowing CORS headers to be passed through to the publish tier to support headless and SPA Editor use cases.
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#the_http_request_headers
 
+# Headless Content Fragment API
+"X-Adobe-Accept-Unsupported-API"
+
 $include "./default_clientheaders.any"

--- a/dispatcher/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/filters.any
@@ -36,3 +36,7 @@ $include "./default_filters.any"
 # ContextHub
 /0200 { /type "allow" /url "*/contexthub.pagedata.json" }
 /0201 { /type "allow" /url "/home/users/*.infinity.json" }
+
+# SITES-15655 - Enable API to Get Content Fragments and models on publish
+/0300 { /type "allow" /method "GET" /url "/adobe/sites/cf/models*" }
+/0301 { /type "allow" /method "GET" /url "/adobe/sites/cf/fragments*" }


### PR DESCRIPTION
Enable Open API calls to wknd publish (at least dev.wknd.site)

## Description

We need to allow calls to get fragments and models from the publish instance

## Related Issue

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
