### PR TITLE
#431 - GraphQlIT tests are too strict

### DIFF
--- a/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
+++ b/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -102,7 +103,7 @@ public class GraphQlIT {
         assertNotNull(articleList);
         JsonNode articleListItems = articleList.get("items");
         assertNotNull(articleListItems);
-        assertEquals(7, articleListItems.size());
+        assertTrue(articleListItems.size() > 0);
         assertNotNull(articleListItems.get(0).get("_path"));
         assertNotNull(articleListItems.get(0).get("authorFragment"));
     }
@@ -169,7 +170,7 @@ public class GraphQlIT {
         assertNotNull(articleList);
         JsonNode articleListItems = articleList.get("items");
         assertNotNull(articleListItems);
-        assertEquals(1, articleListItems.size());
+        assertTrue(articleListItems.size() > 0);
         assertEquals(TEST_AUTHOR_FIRST_NAME, articleListItems.get(0).get("authorFragment").get("firstName").asText());
         assertEquals(TEST_AUTHOR_LAST_NAME, articleListItems.get(0).get("authorFragment").get("lastName").asText());
     }
@@ -185,7 +186,7 @@ public class GraphQlIT {
         assertNotNull(adventureListList);
         JsonNode adventureListItems = adventureListList.get("items");
         assertNotNull(adventureListItems);
-        assertEquals(16, adventureListItems.size());
+        assertTrue(adventureListItems.size() > 0);
         JsonNode firstAdventureItem = adventureListItems.get(0);
         assertNotNull(firstAdventureItem.get("_path"));
         assertNotNull(firstAdventureItem.get("title"));


### PR DESCRIPTION
* Suggest not to check for strict number of results, but checking there's at least one result

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adjust test to be less strict on number of results.

<!--- Describe your changes in detail -->

## Related Issue
#431 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Better stability of test suite, not dependent on strict number of results

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
