### PR TITLE
Revert wrongly added test in #433

### DIFF
--- a/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GetPageIT.java
+++ b/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GetPageIT.java
@@ -19,10 +19,7 @@ import com.adobe.cq.testing.client.CQClient;
 import com.adobe.cq.testing.junit.rules.CQAuthorPublishClassRule;
 import com.adobe.cq.testing.junit.rules.CQRule;
 import org.apache.sling.testing.clients.ClientException;
-import org.apache.sling.testing.clients.SlingHttpResponse;
 import org.junit.*;
-
-import static org.junit.Assert.assertEquals;
 
 
 /**
@@ -68,12 +65,6 @@ public class GetPageIT {
     @Test
     public void testHomePageAuthor() throws ClientException {
         adminAuthor.doGet("/", 200);
-    }
-    @Test
-    public void testHomePagePub() throws ClientException {
-        SlingHttpResponse response = adminPublish.doGet("/", 200);
-
-        assertEquals(response.getSlingStatusAsInt(), 200);
     }
 
     /**


### PR DESCRIPTION
Revert unintentional change added on #433
in PR #433 there was a faulty IT test that was introduced into the project unintentionally 
This PR fixes the test in GetPageIT

## Related Issue

CQ-4354966

## How Has This Been Tested?

Tested running the IT test locally against a AEMCS instance with WKND


