### PR TITLE
fix: allow curly braces in password string

### DIFF
--- a/ui.tests/.gitignore
+++ b/ui.tests/.gitignore
@@ -1,1 +1,3 @@
 secret
+test-module/cypress/results
+!test-module/cypress/results/.gitkeep

--- a/ui.tests/test-module/cypress/support/aem.js
+++ b/ui.tests/test-module/cypress/support/aem.js
@@ -44,7 +44,7 @@ Cypress.Commands.add('AEMLogin', function (username, password) {
     cy.get('#login').should('have.attr', 'action', '/libs/granite/core/content/login.html/j_security_check')
 
     cy.get('#username').type(username)
-    cy.get('#password').type(password, { log: false })
+    cy.get('#password').type(password, { log: false, parseSpecialCharSequences: false })
 
     cy.get('#submit-button').click()
     cy.get('coral-shell-content', { timeout: 5000 }).should('exist')


### PR DESCRIPTION
fix: allow curly braces in password string

## Description

If for a chance the admin password contains curly braces `123{456}` cypress will parse them trying to type the value into the password field.
this behavior has been disabled with this commit 
https://docs.cypress.io/api/commands/type

## How Has This Been Tested?

running locally against an AEMCS instance


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
