### PR TITLE
Publish login issue

### DIFF
--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -16,6 +16,18 @@ Include conf.d/variables/custom.vars
 	DocumentRoot "${DOCROOT}"
 	# URI dereferencing algorithm is applied at Sling's level, do not decode parameters here
 	AllowEncodedSlashes NoDecode
+
+    RewriteEngine On
+    RewriteCond %{REQUEST_SCHEME} (.+)
+    RewriteRule ^ - [E=my_request_scheme:%1]
+
+    RewriteCond %{HTTP_HOST} (.+)
+    RewriteRule ^ - [E=my_request_host:%1]
+
+    SetEnvIf Origin "^https?://([^:/]+)" origin_host=$1
+    Header always set Debug-Request-Or "%{origin_host}e"
+
+
 	# Add header breadcrumbs for help in troubleshooting
 	<IfModule mod_headers.c>
 		Header add X-Vhost "publish"
@@ -38,7 +50,9 @@ Include conf.d/variables/custom.vars
 
         SetEnvIfExpr "req_novary('Access-Control-Request-Method') == '' && %{REQUEST_METHOD} == 'OPTIONS' && req_novary('Origin') != ''" CORSType=invalidpreflight CORSProcessing=false
         SetEnvIfExpr "req_novary('Access-Control-Request-Method') != '' && %{REQUEST_METHOD} == 'OPTIONS' && req_novary('Origin') != ''" CORSType=preflight CORSProcessing=true CORSTrusted=false
-        SetEnvIfExpr "req_novary('Origin') -strcmatch '%{REQUEST_SCHEME}://%{HTTP_HOST}*'" CORSType=samedomain CORSProcessing=false
+        #SetEnvIfExpr "req_novary('Origin') -strcmatch '%{REQUEST_SCHEME}://%{HTTP_HOST}*'" CORSType=samedomain CORSProcessing=false CORSTrusted=true
+        SetEnvIfExpr "env('origin_host') == env('my_request_host')" CORSType=samedomain CORSProcessing=false CORSTrusted=true
+        
 
         # For requests that require CORS processing, check if the Origin can be trusted
         SetEnvIfExpr "%{HTTP_HOST} =~ /(.*)/ " ParsedHost=$1
@@ -74,6 +88,15 @@ Include conf.d/variables/custom.vars
         Header always set Access-Control-Allow-Methods "GET" "expr=reqenv('CORSTrusted') == 'true'"
         Header always set Access-Control-Max-Age 1800 "expr=reqenv('CORSTrusted') == 'true'"
         Header always set Access-Control-Allow-Headers "Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers" "expr=reqenv('CORSTrusted') == 'true'"
+
+        # Uncomment while debugging
+        Header always set Debug-CORSProcessing "true" "expr=reqenv('CORSProcessing') == 'true'"
+        Header always set Debug-CORSProcessing "false" "expr=reqenv('CORSProcessing') == 'false'"
+        Header always set Debug-CORSTrusted "false" "expr=reqenv('CORSTrusted') == 'false'"
+        Header always set Debug-CORSTrusted "true" "expr=reqenv('CORSTrusted') == 'true'"
+        Header always set Debug-Request-Scheme "%{my_request_scheme}e"
+        Header always set Debug-Request-Host "%{my_request_host}e"
+        Header always set Debug-Request-Origin "%{origin_host}e"
 
         # Non-CORS or Not Trusted
         Header unset Access-Control-Allow-Credentials "expr=reqenv('CORSProcessing') == 'false' || reqenv('CORSTrusted') == 'false'"

--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -41,8 +41,6 @@ Include conf.d/variables/custom.vars
         SetEnvIfExpr "req_novary('Access-Control-Request-Method') != '' && %{REQUEST_METHOD} == 'OPTIONS' && req_novary('Origin') != ''" CORSType=preflight CORSProcessing=true CORSTrusted=false
         SetEnvIfExpr "req_novary('Origin') -strcmatch 'https://%{HTTP_HOST}*'" CORSType=samedomain CORSProcessing=false CORSTrusted=true
         SetEnvIfExpr "req_novary('Origin') -strcmatch 'http://%{HTTP_HOST}*'" CORSType=samedomain CORSProcessing=false CORSTrusted=true
-        #SetEnvIfExpr "env('origin_host') == env('my_request_host')" CORSType=samedomain CORSProcessing=false CORSTrusted=true
-        
 
         # For requests that require CORS processing, check if the Origin can be trusted
         SetEnvIfExpr "%{HTTP_HOST} =~ /(.*)/ " ParsedHost=$1
@@ -80,10 +78,10 @@ Include conf.d/variables/custom.vars
         Header always set Access-Control-Allow-Headers "Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers" "expr=reqenv('CORSTrusted') == 'true'"
 
         # Uncomment while debugging
-        Header always set Debug-CORSProcessing "true" "expr=reqenv('CORSProcessing') == 'true'"
-        Header always set Debug-CORSProcessing "false" "expr=reqenv('CORSProcessing') == 'false'"
-        Header always set Debug-CORSTrusted "false" "expr=reqenv('CORSTrusted') == 'false'"
-        Header always set Debug-CORSTrusted "true" "expr=reqenv('CORSTrusted') == 'true'"
+        # Header always set Debug-CORSProcessing "true" "expr=reqenv('CORSProcessing') == 'true'"
+        # Header always set Debug-CORSProcessing "false" "expr=reqenv('CORSProcessing') == 'false'"
+        # Header always set Debug-CORSTrusted "false" "expr=reqenv('CORSTrusted') == 'false'"
+        # Header always set Debug-CORSTrusted "true" "expr=reqenv('CORSTrusted') == 'true'"
 
         # Non-CORS or Not Trusted
         Header unset Access-Control-Allow-Credentials "expr=reqenv('CORSProcessing') == 'false' || reqenv('CORSTrusted') == 'false'"

--- a/dispatcher/src/conf.d/available_vhosts/wknd.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/wknd.vhost
@@ -17,17 +17,6 @@ Include conf.d/variables/custom.vars
 	# URI dereferencing algorithm is applied at Sling's level, do not decode parameters here
 	AllowEncodedSlashes NoDecode
 
-    RewriteEngine On
-    RewriteCond %{REQUEST_SCHEME} (.+)
-    RewriteRule ^ - [E=my_request_scheme:%1]
-
-    RewriteCond %{HTTP_HOST} (.+)
-    RewriteRule ^ - [E=my_request_host:%1]
-
-    SetEnvIf Origin "^https?://([^:/]+)" origin_host=$1
-    Header always set Debug-Request-Or "%{origin_host}e"
-
-
 	# Add header breadcrumbs for help in troubleshooting
 	<IfModule mod_headers.c>
 		Header add X-Vhost "publish"
@@ -50,8 +39,9 @@ Include conf.d/variables/custom.vars
 
         SetEnvIfExpr "req_novary('Access-Control-Request-Method') == '' && %{REQUEST_METHOD} == 'OPTIONS' && req_novary('Origin') != ''" CORSType=invalidpreflight CORSProcessing=false
         SetEnvIfExpr "req_novary('Access-Control-Request-Method') != '' && %{REQUEST_METHOD} == 'OPTIONS' && req_novary('Origin') != ''" CORSType=preflight CORSProcessing=true CORSTrusted=false
-        #SetEnvIfExpr "req_novary('Origin') -strcmatch '%{REQUEST_SCHEME}://%{HTTP_HOST}*'" CORSType=samedomain CORSProcessing=false CORSTrusted=true
-        SetEnvIfExpr "env('origin_host') == env('my_request_host')" CORSType=samedomain CORSProcessing=false CORSTrusted=true
+        SetEnvIfExpr "req_novary('Origin') -strcmatch 'https://%{HTTP_HOST}*'" CORSType=samedomain CORSProcessing=false CORSTrusted=true
+        SetEnvIfExpr "req_novary('Origin') -strcmatch 'http://%{HTTP_HOST}*'" CORSType=samedomain CORSProcessing=false CORSTrusted=true
+        #SetEnvIfExpr "env('origin_host') == env('my_request_host')" CORSType=samedomain CORSProcessing=false CORSTrusted=true
         
 
         # For requests that require CORS processing, check if the Origin can be trusted
@@ -94,9 +84,6 @@ Include conf.d/variables/custom.vars
         Header always set Debug-CORSProcessing "false" "expr=reqenv('CORSProcessing') == 'false'"
         Header always set Debug-CORSTrusted "false" "expr=reqenv('CORSTrusted') == 'false'"
         Header always set Debug-CORSTrusted "true" "expr=reqenv('CORSTrusted') == 'true'"
-        Header always set Debug-Request-Scheme "%{my_request_scheme}e"
-        Header always set Debug-Request-Host "%{my_request_host}e"
-        Header always set Debug-Request-Origin "%{origin_host}e"
 
         # Non-CORS or Not Trusted
         Header unset Access-Control-Allow-Credentials "expr=reqenv('CORSProcessing') == 'false' || reqenv('CORSTrusted') == 'false'"


### PR DESCRIPTION
## Description

The login on the Publish service (asmith/asmith) was not working resulting in 204 responses for **/system/sling/login/j_security_check**. This was happening cause REQUEST_SCHEME value is http (and not https) thus same-origin check fails and forces the CORS processing, thus 204.

## Related Issue

https://github.com/adobe/aem-guides-wknd/issues/448

## Motivation and Context

Handle both http and https REQUEST_SCHEME, the SSL termination might happen before request reaches the dispatcher/Apache POD.

## How Has This Been Tested?

Tested on Tech Marketings Sandox and Prod program, see https://wknd.enablementadobe.com/us/en.html

## Screenshots (if appropriate):


![Screenshot 2024-03-22 at 10 59 53 AM](https://github.com/adobe/aem-guides-wknd/assets/2335734/234ab031-69b1-4777-b666-59000e137bcd)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
