### PR TITLE
fix for redirecting to http homepage first instead of https

### DIFF
--- a/dispatcher/src/conf.d/rewrites/rewrite.rules
+++ b/dispatcher/src/conf.d/rewrites/rewrite.rules
@@ -16,7 +16,11 @@ RewriteRule ^(.*)$ https://wknd.site%{REQUEST_URI} [R=301,L,E=cdncache]
 
 # redirect all root traffic to US home page
 RewriteCond %{REQUEST_URI} ^/?$
+RewriteCond %{HTTP:X-Forwarded-Proto} ^$
 RewriteRule ^(/)$ /us/en.html [R=301,L,E=cdncache]
+
+RewriteCond %{REQUEST_URI} ^/?$
+RewriteRule ^(/)$ %{HTTP:X-Forwarded-Proto}://%{HTTP_HOST}/us/en.html [R=301,L,E=cdncache]
 
 RewriteCond %{REQUEST_URI} !^/apps
 RewriteCond %{REQUEST_URI} !^/bin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

During UI test run we noticed that homepage is being redirected first to http and then to https instead of https directly.

## Related Issue

CQ-4357566

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Executed deployment pipeline.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
