### PR TITLE
GraphQLIT - Improve code quality and provide separation of  concerns.

### DIFF
--- a/it.tests/README.md
+++ b/it.tests/README.md
@@ -4,6 +4,12 @@ This module contains integration tests. These tests will be run in an AEM as a C
 
 ## Run Tests locally
 
+Some tests are running on publish instance, to deploy WKND content there run the following command:
+
+```
+mvn clean install -PautoInstallSinglePackagePublish
+```
+
 To execute the integration tests locally use the following command:
 
 ```

--- a/it.tests/README.md
+++ b/it.tests/README.md
@@ -4,7 +4,7 @@ This module contains integration tests. These tests will be run in an AEM as a C
 
 ## Run Tests locally
 
-Some tests are running on publish instance, to deploy WKND content there run the following command:
+GraphQLEndpointIT test relying on running publish instance with persisted query deployed, to deploy WKND content there run the following command:
 
 ```
 mvn clean install -PautoInstallSinglePackagePublish

--- a/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQLIT.java
+++ b/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQLIT.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * GraphQL tests.
  */
-public class GraphQlIT {
+public class GraphQLIT {
 
     private static final String TEST_AUTHOR_FIRST_NAME = "Ian";
 
@@ -54,7 +54,7 @@ public class GraphQlIT {
 
     private static final String WKND_SHARED_GRAPHQL_ENDPOINT = "/content/_cq_graphql/wknd-shared/endpoint.json";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(GraphQlIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(GraphQLIT.class);
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();

--- a/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
+++ b/it.tests/src/main/java/com/adobe/aem/guides/wknd/it/tests/GraphQlIT.java
@@ -182,6 +182,6 @@ public class GraphQlIT {
         assertTrue(queryOptional.isPresent());
         PersistedQuery adventuresQuery = queryOptional.get();
         assertEquals("/wknd-shared/settings/graphql/persistentQueries/adventures-all", adventuresQuery.getLongPath());
-        assertThat(adventuresQuery.getQuery(), containsString("adventureList {"));
+        assertThat(adventuresQuery.getQuery(), containsString("adventureList"));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Improved test & README

Customer IT tests run after the product tests are run and suppose to test customer's added functionality.

### Removed tests

- testQueryWithSyntaxError
- testQueryWithErrorResponse

Those tests were testing `aemHeadlessClient` itself (ability to throw an AEMHeadlessClientException), which should be part of product tests and not a customer IT tests.

### Fixed potential NPE

- testListPersistedQueries

### Updated README.md:

Test `GraphQLEndpointIT`requred publish instance up and running and having persisted query published, updated documentation to reflect this.

### Styling

Test GraphQlIT renamed to GraphQ**L**IT, to as L stands for "Language", which is also a part of "GraphQL" abbreviation.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Improve code quality and provide separation of  concerns.

## How Has This Been Tested?

Locally and on cloud environment

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
