### PR TITLE
sync dispatcher immutable files with Dispatcher SDK and image v2.0.232

### DIFF
--- a/dispatcher/pom.xml
+++ b/dispatcher/pom.xml
@@ -53,13 +53,13 @@
                                 <!-- rules being inserted by archetype-pre-package.groovy -->
                                 <requireTextFileChecksum>
                                     <file>src/conf.d/available_vhosts/default.vhost</file>
-                                    <checksum>d4bc425c3f0ce825450019ce2501e14e</checksum>
+                                    <checksum>758e78c452d8d93685eaaf6d78561828</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/available_vhosts/default.vhost</message>
                                 </requireTextFileChecksum>
                                 <requireTextFileChecksum>
                                     <file>src/conf.d/dispatcher_vhost.conf</file>
-                                    <checksum>8be9f535a8a4d15bd895cebb2a9e03ad</checksum>
+                                    <checksum>37d6ff3af540dea2d0b3eb6fcbd373cc</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.d/dispatcher_vhost.conf</message>
                                 </requireTextFileChecksum>
@@ -77,7 +77,7 @@
                                 </requireTextFileChecksum>
                                 <requireTextFileChecksum>
                                     <file>src/conf.dispatcher.d/available_farms/default.farm</file>
-                                    <checksum>3d8a01ff3465ac69b229bff6e90ecdeb</checksum>
+                                    <checksum>c5e805cade08939226c3c69ecd6ebc3a</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/available_farms/default.farm</message>
                                 </requireTextFileChecksum>
@@ -113,7 +113,7 @@
                                 </requireTextFileChecksum>
                                 <requireTextFileChecksum>
                                     <file>src/conf.dispatcher.d/filters/default_filters.any</file>
-                                    <checksum>33ab21977347e87a04dac059cd15fc06</checksum>
+                                    <checksum>89984e2bace630d1f2e160d1a01cf91f</checksum>
                                     <type>md5</type>
                                     <message>There have been changes detected in a file which is supposed to be immutable according to https://docs.adobe.com/content/help/en/experience-manager-cloud-service/implementing/content-delivery/disp-overview.html#file-structure: src/conf.dispatcher.d/filters/default_filters.any</message>
                                 </requireTextFileChecksum>

--- a/dispatcher/src/conf.d/available_vhosts/default.vhost
+++ b/dispatcher/src/conf.d/available_vhosts/default.vhost
@@ -28,7 +28,7 @@ Include conf.d/variables/custom.vars
 			# Some items cache with the wrong mime type
 			# Use this option to use the name to auto-detect mime types when cached improperly
 			ModMimeUsePathInfo On
-			# Use this option to avoid cache poisioning
+			# Use this option to avoid cache poisoning
 			# Sling will return /content/image.jpg as well as /content/image.jpg/ but apache can't search /content/image.jpg/ as a file
 			# Apache will treat that like a directory.  This assures the last slash is never stored in cache
 			DirectorySlash Off

--- a/dispatcher/src/conf.d/dispatcher_vhost.conf
+++ b/dispatcher/src/conf.d/dispatcher_vhost.conf
@@ -15,8 +15,6 @@ Include conf.d/variables/global.vars
 
 # Liveness probe URL
 Alias "/system/probes/live" probes/live-status.json
-# Readiness probe URL
-Alias "/system/probes/ready" probes/ready-status.json
 # Startup probe URL
 Alias "/system/probes/start" probes/startup-status.json
 
@@ -111,16 +109,53 @@ Alias "/system/probes/start" probes/startup-status.json
 	</LocationMatch>
 </IfDefine>
 
-# Legacy /systemready mapped to new Health probe URL /system/probes/health in AEM
-<Location "/systemready">
-	ProxyPass http://${AEM_HOST}:${AEM_PORT}/system/probes/health
-	RewriteEngine Off
-</Location>
+# managed redirect maps not configured (= backward-compatible)
+<IfFile !opt-in/managed-rewrite-maps.yaml>
+	# Legacy /systemready mapped to new Health probe URL /system/probes/health in AEM
+	<Location "/systemready">
+		ProxyPass http://${AEM_HOST}:${AEM_PORT}/system/probes/health
+		RewriteEngine Off
+	</Location>
 
-# Allow ingressroute checks through on /system/probes/health (regardless of dispatcher filters)
-<Location "/system/probes/health">
-	ProxyPass http://${AEM_HOST}:${AEM_PORT}/system/probes/health
-	RewriteEngine Off
+	# Allow ingressroute checks through on /system/probes/health (regardless of dispatcher filters)
+	<Location "/system/probes/health">
+		ProxyPass http://${AEM_HOST}:${AEM_PORT}/system/probes/health
+		RewriteEngine Off
+	</Location>
+</IfFile>
+# managed redirect maps configured
+<IfFile opt-in/managed-rewrite-maps.yaml>
+	# check if traffic can be already allowed to pass (404/redirects not existing yet prevention)
+	<IfFile /tmp/rewrites/ready>
+		# Legacy /systemready mapped to new Health probe URL /system/probes/health in AEM
+		<Location "/systemready">
+			ProxyPass http://${AEM_HOST}:${AEM_PORT}/system/probes/health
+			RewriteEngine Off
+		</Location>
+
+		# Allow ingressroute checks through on /system/probes/health (regardless of dispatcher filters)
+		<Location "/system/probes/health">
+			ProxyPass http://${AEM_HOST}:${AEM_PORT}/system/probes/health
+			RewriteEngine Off
+		</Location>
+	</IfFile>
+	# else forcing "403 Forbidden" for Health probes
+	# "Any code greater than or equal to 200 and less than 400 indicates success. Any other code indicates failure."
+	# as per https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+	<IfFile !/tmp/rewrites/ready>
+	    <Location "/systemready">
+	        Require all denied
+	    </Location>
+	    <Location "/system/probes/health">
+	        Require all denied
+	    </Location>
+	</IfFile>
+</IfFile>
+
+# Readiness probe for K8S Endpoints also depends on AEM readiness probe
+<Location "/system/probes/ready">
+    ProxyPass http://${AEM_HOST}:${AEM_PORT}/system/probes/ready
+    RewriteEngine Off
 </Location>
 
 # Allow access to CRXDE on dev environment
@@ -228,48 +263,48 @@ Alias "/gitinit-status" metadata/gitinit-status.json
     Require expr "%{HTTP_HOST} == '${POD_NAME}'"
 </Directory>
 
-# Dedicated vhost for EaaS:
+# Dedicated vhost for Adobe proxy testing:
 # (currently disabled, but customers can expect it to be enabled in future versions - CQ-4349728)
-#<VirtualHost *:80>
-#	ServerName	"test.eaas"
-#	# possibility to make overrides before directives in this vhost
-#	IncludeOptional conf.d/includes/first-listed-vhost.pre.includes
-#	# since this vhost is first-listed one, this setting influences other vhosts - see https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestfieldsize
-#	LimitRequestFieldSize 32768
-#	DocumentRoot /var/www/localhost/htdocs
-#	AllowEncodedSlashes NoDecode
-#	<IfModule mod_headers.c>
-#		Header add X-Vhost "test.eaas"
-#	</IfModule>
-#	<Directory "/var/www/localhost/htdocs">
-#		Options Indexes FollowSymLinks
-#		AllowOverride None
-#		Require all granted
-#	</Directory>
-#
-#	# SKYOPS-49434: Allow EaaS to access publish instance directly for dev and stage environments when test.eaas vhost is requested
-#	<IfDefine ENVIRONMENT_DEV>
-#		<LocationMatch "/">
-#			ProxyPassMatch http://${AEM_HOST}:${AEM_PORT}
-#			RewriteEngine Off
-#		</LocationMatch>
-#	</IfDefine>
-#	<IfDefine ENVIRONMENT_STAGE>
-#		<LocationMatch "/">
-#			ProxyPassMatch http://${AEM_HOST}:${AEM_PORT}
-#			RewriteEngine Off
-#		</LocationMatch>
-#	</IfDefine>
-#	# 403 Forbidden on prod
-#	<IfDefine ENVIRONMENT_PROD>
-#		<IfModule mod_rewrite.c>
-#			RewriteEngine	on
-#			RewriteRule ^ - [F]
-#		</IfModule>
-#	</IfDefine>
-#	# possibility to make overrides after directives in this vhost
-#	IncludeOptional conf.d/includes/first-listed-vhost.post.includes
-#</VirtualHost>
+<VirtualHost *:80>
+	ServerName	"test.proxy"
+	# possibility to make overrides before directives in this vhost
+	IncludeOptional conf.d/includes/first-listed-vhost.pre.includes
+	# since this vhost is first-listed one, this setting influences other vhosts - see https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestfieldsize
+	LimitRequestFieldSize 32768
+	DocumentRoot /var/www/localhost/htdocs
+	AllowEncodedSlashes NoDecode
+	<IfModule mod_headers.c>
+		Header add X-Vhost "test.proxy"
+	</IfModule>
+	<Directory "/var/www/localhost/htdocs">
+		Options Indexes FollowSymLinks
+		AllowOverride None
+		Require all granted
+	</Directory>
+
+	# SKYOPS-49434: Allow EaaS to access publish instance directly for dev and stage environments when test.proxy vhost is requested
+	<IfDefine ENVIRONMENT_DEV>
+		<LocationMatch "/">
+			ProxyPassMatch http://${AEM_HOST}:${AEM_PORT}
+			RewriteEngine Off
+		</LocationMatch>
+	</IfDefine>
+	<IfDefine ENVIRONMENT_STAGE>
+		<LocationMatch "/">
+			ProxyPassMatch http://${AEM_HOST}:${AEM_PORT}
+			RewriteEngine Off
+		</LocationMatch>
+	</IfDefine>
+	# 403 Forbidden on prod
+	<IfDefine ENVIRONMENT_PROD>
+		<IfModule mod_rewrite.c>
+			RewriteEngine	on
+			RewriteRule ^ - [F]
+		</IfModule>
+	</IfDefine>
+	# possibility to make overrides after directives in this vhost
+	IncludeOptional conf.d/includes/first-listed-vhost.post.includes
+</VirtualHost>
 
 # Customer's vhosts:
 Include conf.d/enabled_vhosts/*.vhost

--- a/dispatcher/src/conf.dispatcher.d/available_farms/default.farm
+++ b/dispatcher/src/conf.dispatcher.d/available_farms/default.farm
@@ -9,6 +9,9 @@
 #
 
 /publishfarm {
+	# Dispatcher Debugging Flag
+	# Include X-Cache-Info response header if X-Dispatcher-Info is in request header
+	# /info "1"
 	# client headers which should be passed through to the render instances
 	# (feature supported since dispatcher build 2.6.3.5222)
 	/clientheaders {
@@ -34,6 +37,7 @@
 	#	/url    "/libs/granite/dispatcher/content/vanityUrls.html"
 	#	/file   "/tmp/vanity_urls"
 	#	/delay  300
+	#	/loadOnStartup 1
 	# }
 	# allow propagation of replication posts (should seldomly be used)
 	/propagateSyndPost "0"
@@ -86,9 +90,17 @@
 		}
 		# The ignoreUrlParams section contains query string parameter names that
 		# should be ignored when determining whether some request's output can be
-		# cached or delivered from cache.
+		# cached or delivered from cache. Please only enable one of the examples below.
+		# The recommended setting is to ignore all parameters and selectively allow them. e.g.
+		# /ignoreUrlParams {
+		# 	/0001 { /glob "*" /type "allow" }
+		# 	/0002 { /glob "page" /type "deny" }
+		# 	/0003 { /glob "product" /type "deny" }
+		# }
+		#
 		# In this example configuration, the "q" parameter will be ignored as 
 		# well as general marketing related parameters such as e.g. utm_campaign.
+		# If any other parameters are specified the request gets forwarded to the publisher.
 		# Marketing parameters can normally be ignored on most websites as they are tracked
 		# through different means. 
 		# /ignoreUrlParams {

--- a/dispatcher/src/conf.dispatcher.d/filters/default_filters.any
+++ b/dispatcher/src/conf.dispatcher.d/filters/default_filters.any
@@ -96,8 +96,8 @@
 # GraphQL Persisted Queries & preflight requests
 /0061 { /type "allow" /method '(GET|POST|OPTIONS)' /url "/graphql/execute.json*" }
 
-# Allow Forms Document Services requests
-/0062 { /type "allow" /method '(GET|POST)' /url "/adobe/forms/*" }
+# Allow Adaptive Form & Document Services requests
+/0062 { /type "allow" /method '(GET|POST|OPTIONS)' /url "/adobe/forms/*" }
 
 # Allow PUT for Forms DocAssurance Services Decryption API
 /0063 { /type "allow" /method "PUT" /url "/adobe/forms/document/assure/encrypt" }


### PR DESCRIPTION
sync dispatcher immutable files with Dispatcher SDK and image v2.0.232

## Description

Since the previous sync of dispatcher immutable files with Dispatcher SDK and image was from version 2.0.191 in October 2023 and AEM CS releases already progressed further, including dispatcher image and SDK tooling containing newer files, it resulted already in customer using latest public AEM CS releases being out of sync and reporting issues like previously in https://github.com/adobe/aem-project-archetype/issues/1043

Hence we propose to sync those files with the ones from the latest Dispatcher SDK and image v2.0.232 in order for validation scripts not to fail in immutable files compatibility check step as described in https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/validation-debug.html?lang=en#third-phase

## Related Issue

* https://github.com/adobe/aem-project-archetype/issues/1043
* https://github.com/adobe/aem-project-archetype/pull/1237

## Motivation and Context

Not to fail immutable files validation step described in https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/implementing/content-delivery/validation-debug.html?lang=en#third-phase when using Dispatcher SDK tooling from the latest AEM CS releases.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
