### PR TITLE
fix(build): update public key for google linux pkg repo

### DIFF
--- a/ui.tests/Dockerfile
+++ b/ui.tests/Dockerfile
@@ -15,6 +15,7 @@
 FROM cypress/included:13.14.1
 
 ENV APP_PATH /usr/src/app
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | tee /etc/apt/trusted.gpg.d/google.asc >/dev/null
 RUN apt -qqy update \
     # Generic dependencies
     && apt -qqy --no-install-recommends install \


### PR DESCRIPTION
## Motivation and Context

this pr fixes error during the build:
```
W: GPG error: https://dl.google.com/linux/chrome/deb stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 32EE5355A6BC6E42
```
