### PR TITLE
SITES-24960 Language toggle does not communicate correct expanded / collapsed state

### DIFF
--- a/ui.frontend/src/main/webpack/components/languagenavigation/languagenavigation.js
+++ b/ui.frontend/src/main/webpack/components/languagenavigation/languagenavigation.js
@@ -60,7 +60,7 @@ jQuery(function ($) {
 
             //allow users to click anywhere to close language switcher
             window.onclick = function (event) {
-                if (!event.target.matches(navToggleHeader) && $(navToggleHeader).hasClass('open')) {
+                if (!event.target.matches(langNavToggleHeader) && $(langNavToggleHeader).hasClass('open')) {
                     $(CMP_SELECTOR + ' .cmp-languagenavigation').removeClass('showMenu');
                     $(langNavToggleHeader).removeClass('open');
                     $(langNavToggleHeader).attr('aria-expanded', false);

--- a/ui.frontend/src/main/webpack/components/languagenavigation/languagenavigation.js
+++ b/ui.frontend/src/main/webpack/components/languagenavigation/languagenavigation.js
@@ -26,7 +26,7 @@ jQuery(function ($) {
             ACTIVE_LINK_SELECTOR = '.cmp-languagenavigation__item--active > .cmp-languagenavigation__item-link',
             ACTIVE_COUNTRY_SELECTOR = '.cmp-languagenavigation__item--level-0.cmp-languagenavigation__item--active',
             langNav = $(CMP_SELECTOR).not('[' + CMP_PROCESSED + '=\'true\']'),
-            navToggleHeader = '#langNavToggleHeader',
+            langNavToggleHeader = '#langNavToggleHeader',
             activeCountryImg,
             activeLanguage,
             toggleButton,
@@ -54,16 +54,16 @@ jQuery(function ($) {
                 displayPosition = $(this).position().left - 240;
                 $(CMP_SELECTOR + ' .cmp-languagenavigation').css({ left: displayPosition });
                 $(CMP_SELECTOR + ' .cmp-languagenavigation').toggleClass('showMenu');
-                $(navToggleHeader).toggleClass('open');
-                $(navToggleHeader).attr('aria-expanded', true);
+                $(langNavToggleHeader).toggleClass('open');
+                $(langNavToggleHeader).attr('aria-expanded', true);
             });
 
             //allow users to click anywhere to close language switcher
             window.onclick = function (event) {
                 if (!event.target.matches(navToggleHeader) && $(navToggleHeader).hasClass('open')) {
                     $(CMP_SELECTOR + ' .cmp-languagenavigation').removeClass('showMenu');
-                    $(navToggleHeader).removeClass('open');
-                    $(navToggleHeader).attr('aria-expanded', false);
+                    $(langNavToggleHeader).removeClass('open');
+                    $(langNavToggleHeader).attr('aria-expanded', false);
                 }
             };
 

--- a/ui.frontend/src/main/webpack/components/languagenavigation/languagenavigation.js
+++ b/ui.frontend/src/main/webpack/components/languagenavigation/languagenavigation.js
@@ -26,6 +26,7 @@ jQuery(function ($) {
             ACTIVE_LINK_SELECTOR = '.cmp-languagenavigation__item--active > .cmp-languagenavigation__item-link',
             ACTIVE_COUNTRY_SELECTOR = '.cmp-languagenavigation__item--level-0.cmp-languagenavigation__item--active',
             langNav = $(CMP_SELECTOR).not('[' + CMP_PROCESSED + '=\'true\']'),
+            navToggleHeader = '#langNavToggleHeader',
             activeCountryImg,
             activeLanguage,
             toggleButton,
@@ -49,18 +50,20 @@ jQuery(function ($) {
             $(langNav).prepend(toggleButton);
 
             //attach toggle to change languages
-            $('#langNavToggleHeader').click(function () {
+            $(navToggleHeader).click(function () {
                 displayPosition = $(this).position().left - 240;
                 $(CMP_SELECTOR + ' .cmp-languagenavigation').css({ left: displayPosition });
                 $(CMP_SELECTOR + ' .cmp-languagenavigation').toggleClass('showMenu');
-                $('#langNavToggleHeader').toggleClass('open');
+                $(navToggleHeader).toggleClass('open');
+                $(navToggleHeader).attr('aria-expanded', true);
             });
 
             //allow users to click anywhere to close language switcher
             window.onclick = function (event) {
-                if (!event.target.matches('#langNavToggleHeader') && $('#langNavToggleHeader').hasClass('open')) {
+                if (!event.target.matches(navToggleHeader) && $(navToggleHeader).hasClass('open')) {
                     $(CMP_SELECTOR + ' .cmp-languagenavigation').removeClass('showMenu');
-                    $('#langNavToggleHeader').removeClass('open');
+                    $(navToggleHeader).removeClass('open');
+                    $(navToggleHeader).attr('aria-expanded', false);
                 }
             };
 

--- a/ui.frontend/src/main/webpack/components/languagenavigation/languagenavigation.js
+++ b/ui.frontend/src/main/webpack/components/languagenavigation/languagenavigation.js
@@ -50,7 +50,7 @@ jQuery(function ($) {
             $(langNav).prepend(toggleButton);
 
             //attach toggle to change languages
-            $(navToggleHeader).click(function () {
+            $(langNavToggleHeader).click(function () {
                 displayPosition = $(this).position().left - 240;
                 $(CMP_SELECTOR + ' .cmp-languagenavigation').css({ left: displayPosition });
                 $(CMP_SELECTOR + ' .cmp-languagenavigation').toggleClass('showMenu');


### PR DESCRIPTION
## Description

Added aria-expanded attribute and toggle it

## Related Issue

[SITES-24960](https://jira.corp.adobe.com/browse/SITES-24960)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
